### PR TITLE
task/88 standardize documentation styles and messages

### DIFF
--- a/src/app/website/about/about-carbon-ldp.view.html
+++ b/src/app/website/about/about-carbon-ldp.view.html
@@ -22,7 +22,9 @@
 
 			<article class="ui vertical segment" id="article">
 
-				<h1>About Carbon LDP</h1>
+				<header>
+					<h1>About Carbon LDP</h1>
+				</header>
 
 				<!--
 				<div class="ui message">

--- a/src/app/website/community-and-support/community-and-support.view.html
+++ b/src/app/website/community-and-support/community-and-support.view.html
@@ -25,15 +25,19 @@
 
 			<article class="ui vertical segment" id="article">
 
-				<h1>Community &amp; Support</h1>
-
+				<header>
+					<h1>Community &amp; Support</h1>
+				</header>
 
 				<div class="ui message">
-					<p class="larger">Here, you will find a number of ways to participate in our growing community, provide feedback, and get support.</p>
+					<div class="content">
+						<p>Here, you will find a number of ways to participate in our growing community, provide feedback, and get support.</p>
 
-					<p>We care about your opinion and we want to address your questions, needs, and issues as quickly as possible. Carbon LDP is incredible software, but with your help, we can make
-						it better. We urge you to register for the beta, create new applications, and share your experiences with us. We'll do our best to address your feedback in a timely manner.</p>
+					</div>
 				</div>
+				<p>We care about your opinion and we want to address your questions, needs, and issues as quickly as possible. Carbon LDP is incredible software, but with your help, we can make
+					it better. We urge you to register for the beta, create new applications, and share your experiences with us. We'll do our best to address your feedback in a timely manner.</p>
+
 
 				<section>
 					<h2 class="ui header">Register for the Beta and Community Support</h2>

--- a/src/app/website/community-and-support/community-and-support.view.html
+++ b/src/app/website/community-and-support/community-and-support.view.html
@@ -87,7 +87,8 @@
 						<p>Gitter is an instant messaging and chat room system for developers and users of GitHub repositories.
 							Carbon LDP staff and community users can often be found listening and lingering in the following rooms.
 						</p>
-						<p><i class="big comments icon"></i> <strong><a href="https://gitter.im/CarbonLDP/carbonldp">carbonldp</a></strong> - for general discussions related to using Carbon LDP
+						<p><i class="big comments outline icon"></i> <strong><a href="https://gitter.im/CarbonLDP/carbonldp">carbonldp</a></strong> - for general discussions related to using Carbon
+							LDP
 							(Platform,
 							REST API, product
 							documentation)</p>

--- a/src/app/website/documentation/documentation.view.scss
+++ b/src/app/website/documentation/documentation.view.scss
@@ -29,6 +29,10 @@ documents {
 		padding-right: 0;
 	}
 
+	.ui.breadcrumb > .section:hover {
+		cursor: pointer;
+	}
+
 	a.outsidelink {
 		color: black;
 		border-bottom: 1px dotted #f89828;

--- a/src/app/website/documentation/essential-concepts/carbon-ldp-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/carbon-ldp-concepts.view.html
@@ -3,9 +3,9 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
 				<i class="right chevron icon divider"></i>
-				<span class="section">Essential Concepts</span>
+				<a class="section" [routerLink]="[ '../essential-concepts' ]">Essential Concepts</a>
 				<i class="right arrow icon divider"></i>
 				<div class="active section">Carbon LDP Concepts</div>
 			</div>

--- a/src/app/website/documentation/essential-concepts/carbon-ldp-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/carbon-ldp-concepts.view.html
@@ -10,7 +10,6 @@
 				<div class="active section">Carbon LDP Concepts</div>
 			</div>
 
-			<h1>Carbon LDP Concepts</h1>
 		</div>
 	</div>
 
@@ -18,6 +17,9 @@
 		<div class="twelve wide column">
 
 			<article class="ui vertical segment" id="article">
+				<header>
+					<h1>Carbon LDP Concepts</h1>
+				</header>
 
 				<div class="ui message">
 					<div class="content">

--- a/src/app/website/documentation/essential-concepts/carbon-ldp-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/carbon-ldp-concepts.view.html
@@ -21,7 +21,7 @@
 
 				<div class="ui message">
 					<div class="content">
-						<p class="larger">Carbon LDP is a cloud-based Linked Data Platform for building, hosting,
+						<p>Carbon LDP is a cloud-based Linked Data Platform for building, hosting,
 							managing, and running web applications of all types. In addition to standard LDP
 							capabilities, Carbon delivers one-of-a-kind features that can transform the way you work.
 							This document provides an introduction to some of the features and concepts that make Carbon

--- a/src/app/website/documentation/essential-concepts/essential-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/essential-concepts.view.html
@@ -2,8 +2,9 @@
 	<div class="ui center aligned grid description">
 		<div class="ui container" id="essential-concepts">
 			<div class="ui breadcrumb">
-				<span class="section" [routerLink]="['/documentation']">Documentation</span>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
 				<i class="right chevron icon divider"></i>
+				<div class="active section">Essential Concepts</div>
 			</div>
 
 			<div class="ui header">

--- a/src/app/website/documentation/essential-concepts/ldp-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/ldp-concepts.view.html
@@ -10,7 +10,6 @@
 				<div class="active section">Linked Data Platform Concepts</div>
 			</div>
 
-			<h1>Linked Data Platform Concepts</h1>
 
 		</div>
 	</div>
@@ -20,7 +19,9 @@
 
 			<article class="article" id="article">
 
-
+				<header>
+					<h1>Linked Data Platform Concepts</h1>
+				</header>
 				<div class="ui message">
 					<div class="content">
 						<p>Carbon LDP is a standards-compliant Linked Data Platform (LDP), which allows

--- a/src/app/website/documentation/essential-concepts/ldp-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/ldp-concepts.view.html
@@ -3,9 +3,9 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
 				<i class="right chevron icon divider"></i>
-				<span class="section">Essential Concepts</span>
+				<a class="section" [routerLink]="[ '../essential-concepts' ]">Essential Concepts</a>
 				<i class="right arrow icon divider"></i>
 				<div class="active section">Linked Data Platform Concepts</div>
 			</div>

--- a/src/app/website/documentation/essential-concepts/ldp-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/ldp-concepts.view.html
@@ -23,7 +23,7 @@
 
 				<div class="ui message">
 					<div class="content">
-						<p class="larger">Carbon LDP is a standards-compliant Linked Data Platform (LDP), which allows
+						<p>Carbon LDP is a standards-compliant Linked Data Platform (LDP), which allows
 							you to work with RDF and to link data using HTTP and familiar web development tools and
 							techniques. While Carbon provides much more than the W3C recommends, this document provides
 							an introduction to the standard Linked Data Platform concepts.</p>

--- a/src/app/website/documentation/essential-concepts/linked-data-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/linked-data-concepts.view.html
@@ -26,7 +26,7 @@
 
 				<div class="ui message">
 					<div class="content">
-						<p class="larger">Carbon LDP applications are inherently Linked Data applications. The term
+						<p>Carbon LDP applications are inherently Linked Data applications. The term
 							&quot;Linked Data&quot; refers to an information publishing approach that puts linking at
 							the heart of the notion of data, and uses the linking technologies provided by the Web to
 							enable the creation of a global distributed database. By linking data within your

--- a/src/app/website/documentation/essential-concepts/linked-data-concepts.view.html
+++ b/src/app/website/documentation/essential-concepts/linked-data-concepts.view.html
@@ -11,10 +11,13 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span> <i class="right chevron icon divider"></i> <span class="section">Essential Concepts</span> <i class="right arrow icon divider"></i>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
+				<i class="right chevron icon divider"></i>
+				<a class="section" [routerLink]="[ '../essential-concepts' ]">Essential Concepts</a>
+				<i class="right arrow icon divider"></i>
+				<div class="active section">Linked Data Concepts</div>
 			</div>
 
-			<h1>Linked Data Concepts</h1>
 		</div>
 	</div>
 
@@ -22,7 +25,9 @@
 		<div class="twelve wide column">
 
 			<article class="ui vertical segment" id="article">
-
+				<header>
+					<h1>Linked Data Concepts</h1>
+				</header>
 
 				<div class="ui message">
 					<div class="content">

--- a/src/app/website/documentation/javascript-sdk/getting-started.view.html
+++ b/src/app/website/documentation/javascript-sdk/getting-started.view.html
@@ -40,7 +40,7 @@
 
 					<div class="ui message">
 						<div class="content">
-							<p class="larger">
+							<p>
 								This guide introduces you to the use of the Carbon JavaScript SDK. In it you will find an
 								installation guide and the basic methods needed to start using our platform.
 							</p>

--- a/src/app/website/documentation/javascript-sdk/javascript-sdk.view.html
+++ b/src/app/website/documentation/javascript-sdk/javascript-sdk.view.html
@@ -3,8 +3,9 @@
 		<div class="ui container" id="javascript-sdk">
 
 			<div class="ui breadcrumb">
-				<span class="section" [routerLink]="['..']">Documentation</span>
+				<a class="section" [routerLink]="['..']">Documentation</a>
 				<i class="right chevron icon divider"></i>
+				<div class="active section">JavaScript SDK</div>
 			</div>
 
 			<div class="ui header">

--- a/src/app/website/documentation/javascript-sdk/object-schema.view.html
+++ b/src/app/website/documentation/javascript-sdk/object-schema.view.html
@@ -45,7 +45,7 @@
 					</div>
 					<div class="ui message">
 						<div class="content">
-							<p class="larger">On this document you can find an in depth description of what
+							<p>On this document you can find an in depth description of what
 								is the object schema in Carbon an how to use it.</p>
 						</div>
 					</div>

--- a/src/app/website/documentation/quick-start-guide/quick-start-guide.view.html
+++ b/src/app/website/documentation/quick-start-guide/quick-start-guide.view.html
@@ -2,7 +2,9 @@
 	<div class="row">
 		<div class="sixteen wide column">
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span> <i class="right chevron icon divider"></i>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
+				<i class="right chevron icon divider"></i>
+				<div class="active section">Quick Start Guide</div>
 			</div>
 		</div>
 	</div>

--- a/src/app/website/documentation/rest-api/containers.view.html
+++ b/src/app/website/documentation/rest-api/containers.view.html
@@ -22,8 +22,11 @@
 						<h1 class="ui header">Containers</h1>
 					</header>
 
-					<div class="soon-to-be-documented">Not yet documented.</div>
-
+					<div class="soon-to-be-documented">
+						<p>Sorry, this topic hasn't been documented :(</p>
+					</div>
+					<p>We are doing our best to catch up quickly with the documentation. If you have questions regarding
+						this topic you can always ask us directly through our community. See how <a [routerLink]="[ '/community-and-support' ]">here</a></p>
 					<!--<div class="ui message">-->
 						<!--<div class="content">-->
 							<!--<p class="larger">-->

--- a/src/app/website/documentation/rest-api/containers.view.html
+++ b/src/app/website/documentation/rest-api/containers.view.html
@@ -3,9 +3,9 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
 				<i class="right chevron icon divider"></i>
-				<span class="section">REST API</span>
+				<a class="section" [routerLink]="[ '../rest-api' ]">REST API</a>
 				<i class="right arrow icon divider"></i>
 				<div class="active section">Containers</div>
 			</div>

--- a/src/app/website/documentation/rest-api/getting-started.view.html
+++ b/src/app/website/documentation/rest-api/getting-started.view.html
@@ -19,9 +19,10 @@
 
 					<div class="ui message">
 						<div class="content">
-							<p class="larger">This guide describes how to build an example application using the Carbon LDP REST API. The REST API provides a way for applications to interact with the
+							<p>This guide describes how to build an example application using the Carbon LDP REST API. The REST API provides a way for applications to interact with the
 								Carbon platform
-								using HTTP verbs (GET, POST, PUT, DELETE, etc.) and resources identified by URIs. The REST API is considered to be a lower-level API than the JavaScript SDK. Doing
+								using HTTP verbs (GET, POST, PUT, DELETE, etc.) and resources identified by URIs.<br/> The REST API is considered to be a lower-level API than the JavaScript SDK.
+							Doing
 								things directly with the
 								REST API is generally more tedious than with the JavaScript SDK. However, understanding the REST API provides a lot of insight into how the platform works and can be
 								advantageous for

--- a/src/app/website/documentation/rest-api/getting-started.view.html
+++ b/src/app/website/documentation/rest-api/getting-started.view.html
@@ -3,7 +3,11 @@
 	<div class="row">
 		<div class="sixteen wide column">
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span> <i class="right chevron icon divider"></i> <span class="section">REST API</span> <i class="right arrow icon divider"></i>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
+				<i class="right chevron icon divider"></i>
+				<a class="section" [routerLink]="[ '../rest-api' ]">REST API</a>
+				<i class="right arrow icon divider"></i>
+				<div class="active section">Getting Started</div>
 			</div>
 		</div>
 		<sidebar-component [mobile]="true" [parentElement]="element" [contentReady]="contentReady" class="sixteen wide mobile only column"></sidebar-component>

--- a/src/app/website/documentation/rest-api/interaction-models.view.html
+++ b/src/app/website/documentation/rest-api/interaction-models.view.html
@@ -3,10 +3,12 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span> <i class="right chevron icon divider"></i> <span class="section">REST API</span> <i class="right arrow icon divider"></i>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
+				<i class="right chevron icon divider"></i>
+				<a class="section" [routerLink]="[ '../rest-api' ]">REST API</a>
+				<i class="right arrow icon divider"></i>
+				<div class="active section">Interaction Models</div>
 			</div>
-
-			<h1>Interaction Models</h1>
 
 		</div>
 	</div>
@@ -15,6 +17,9 @@
 		<div class="twelve wide column">
 			<main>
 				<article class="ui vertical segment" id="article">
+					<header>
+						<h1>Interaction Models</h1>
+					</header>
 
 					<p>
 						When you interact with a given document on the Carbon server, you can specify a model that governs how the server behaves with respect to it. A document in Carbon can be

--- a/src/app/website/documentation/rest-api/object-model.view.html
+++ b/src/app/website/documentation/rest-api/object-model.view.html
@@ -18,7 +18,7 @@
 
 					<div class="ui message">
 						<div class="content">
-							<p class="larger">
+							<p>
 								The REST API object model provides a summary of the various types of resources you can manage and interact with using REST.
 							</p>
 						</div>

--- a/src/app/website/documentation/rest-api/object-model.view.html
+++ b/src/app/website/documentation/rest-api/object-model.view.html
@@ -3,10 +3,12 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span> <i class="right chevron icon divider"></i> <span class="section">REST API</span> <i class="right arrow icon divider"></i>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
+				<i class="right chevron icon divider"></i>
+				<a class="section" [routerLink]="[ '../rest-api' ]">REST API</a>
+				<i class="right arrow icon divider"></i>
+				<div class="active section">Object Model</div>
 			</div>
-
-			<h1>REST API Object Model</h1>
 
 		</div>
 	</div>
@@ -15,6 +17,9 @@
 		<div class="twelve wide column">
 			<main>
 				<article class="ui vertical segment" id="article">
+					<header>
+						<h1>REST API Object Model</h1>
+					</header>
 
 					<div class="ui message">
 						<div class="content">

--- a/src/app/website/documentation/rest-api/rdf-source.view.html
+++ b/src/app/website/documentation/rest-api/rdf-source.view.html
@@ -24,7 +24,7 @@
 
 					<div class="ui message">
 						<div class="content">
-							<p class="larger">
+							<p>
 								You can use the Carbon LDP REST API to create, read, update, and delete RDFSource documents. Here's how...
 							</p>
 						</div>

--- a/src/app/website/documentation/rest-api/rdf-source.view.html
+++ b/src/app/website/documentation/rest-api/rdf-source.view.html
@@ -22,334 +22,341 @@
 						<h1 class="ui header">RDF Source</h1>
 					</header>
 
-					<div class="ui message">
-						<div class="content">
-							<p>
-								You can use the Carbon LDP REST API to create, read, update, and delete RDFSource documents. Here's how...
-							</p>
-						</div>
+					<div class="soon-to-be-documented">
+						<p>Sorry, this topic hasn't been documented :(</p>
 					</div>
-
-					<section>
-						<h2 class="ui header">Create</h2>
-
-						<p>To create a new RDFSource, POST the new document to the URI of a container.</p>
-
-						<p>
-							<span class="ui blue horizontal label">POST</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/</code>
-						</p>
-
-						<table class="ui celled table">
-							<thead>
-								<tr>
-									<th>HTTP Header</th>
-									<th>Value</th>
-									<th colspan="1">Required?</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Authorization</td>
-									<td>Basic ...</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>Content-Type</td>
-									<td>
-										Either of:<br/>
-										<ul>
-											<li>text/turtle</li>
-											<li>application/ld+json</li>
-											<li>application/rdf+xml</li>
-											<li>application/trig</li>
-										</ul>
-									</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>Prefer</td>
-									<td><span class="nolink">http://www.w3.org/ns/ldp#Container</span>; rel=interaction-model</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>Slug</td>
-									<td>&#123;john-doe&#125;</td>
-									<td>No</td>
-								</tr>
-							</tbody>
-						</table>
-
-						<p>
-							<strong>Body (required)</strong>
-						</p>
-
-						<p>
-							The RDFSource document is required in the entity body of the request. Following is an example RDFSource document
-							in TRIG syntax. The syntax used for the body must match what you declare in the <code>Content-Type</code>
-							header.
-						</p>
-
-						<pre><code cpHighlight class="turtle">
-						@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-						@prefix ex:&#60;http://www.base22.com/2016/05/ex#&#62;.
-
-						&#60;&#62; &#123;
-							&#60;&#62;
-								a ldp:RDFSource, ex:Person;
-								ex:firstName "John";
-								ex:lastName "Doe";
-								ex:phoneNumber "(555) 555-5555".
-						&#125;
-						</code></pre>
-
-						<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>
-
-						<p>If the optional <code>Slug</code> header is provided, the server will attempt to mint a URI for the document by
-							appending the slug to the path. If the slug is not provided, the server will generate a random long number for the URI.
-						</p>
-						<p>The document's fully qualified URI will be returned by the <code>Location</code> header in the response. Whether or not the server mints the URI using a slug or random long
-							number, the URI will always end with a trailing forward-slash.
-						</p>
-
-						<p>An ETag header will also be returned, which can be used to determine if the document has changed since it was first created or last modified.</p>
-
-						<p><strong>Example request to create RDFSource :</strong></p>
-
-						<pre><code cpHighlight class="turtle">
-						POST /apps/rest-examples/persons/ HTTP/1.1
-						Authorization: Basic
-						Content-Type: application/trig
-						Prefer: http://www.w3.org/ns/ldp#Container; rel=interaction-model
-						Slug: john-doe
-
-						@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
-						@prefix ex:&lt;http://www.base22.com/2016/05/ex#&gt;.
-
-						        a ldp:RDFSource, ex:Person;
-						        ex:firstName "John";
-						        ex:lastName "Doe";
-						        ex:phoneNumber "(555) 555-5555".
-						&#125;
-					</code></pre>
+					<p>We are doing our best to catch up quickly with the documentation. If you have questions regarding
+						this topic you can always ask us directly through our community. See how <a [routerLink]="[ '/community-and-support' ]">here</a></p>
 
 
-					</section>
+					<!--<div class="ui message">-->
+						<!--<div class="content">-->
+							<!--<p>-->
+								<!--You can use the Carbon LDP REST API to create, read, update, and delete RDFSource documents. Here's how...-->
+							<!--</p>-->
+						<!--</div>-->
+					<!--</div>-->
 
-					<section>
-						<h2>Retrieve</h2>
-						<p>To retrieve an RDFSource, issue a GET request to the document's URI.</p>
+					<!--<section>-->
+						<!--<h2 class="ui header">Create</h2>-->
 
-						<p>
-							<span class="ui blue horizontal label">GET</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/&#123;rdfsource&#125;/</code>
-						</p>
+						<!--<p>To create a new RDFSource, POST the new document to the URI of a container.</p>-->
 
-						<table class="ui celled table">
-							<thead>
-								<tr>
-									<th>HTTP Header</th>
-									<th>Value</th>
-									<th colspan="1">Required?</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Authorization</td>
-									<td>Basic ...</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>Accept</td>
-									<td>
-										Either of:<br/>
-										<ul>
-											<li>text/turtle</li>
-											<li>application/ld+json</li>
-											<li>application/rdf+xml</li>
-											<li>application/trig</li>
-										</ul>
-									</td>
-									<td>No</td>
-								</tr>
-								<tr>
-									<td>Prefer</td>
-									<td><span class="nolink">http://www.w3.org/ns/ldp#RDFSource</span>; rel=interaction-model</td>
-									<td>Yes</td>
-								</tr>
-							</tbody>
-						</table>
+						<!--<p>-->
+							<!--<span class="ui blue horizontal label">POST</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/</code>-->
+						<!--</p>-->
 
-						<p>A successful request will result with HTTP status code 200 OK.</p>
+						<!--<table class="ui celled table">-->
+							<!--<thead>-->
+								<!--<tr>-->
+									<!--<th>HTTP Header</th>-->
+									<!--<th>Value</th>-->
+									<!--<th colspan="1">Required?</th>-->
+								<!--</tr>-->
+							<!--</thead>-->
+							<!--<tbody>-->
+								<!--<tr>-->
+									<!--<td>Authorization</td>-->
+									<!--<td>Basic ...</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Content-Type</td>-->
+									<!--<td>-->
+										<!--Either of:<br/>-->
+										<!--<ul>-->
+											<!--<li>text/turtle</li>-->
+											<!--<li>application/ld+json</li>-->
+											<!--<li>application/rdf+xml</li>-->
+											<!--<li>application/trig</li>-->
+										<!--</ul>-->
+									<!--</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Prefer</td>-->
+									<!--<td><span class="nolink">http://www.w3.org/ns/ldp#Container</span>; rel=interaction-model</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Slug</td>-->
+									<!--<td>&#123;john-doe&#125;</td>-->
+									<!--<td>No</td>-->
+								<!--</tr>-->
+							<!--</tbody>-->
+						<!--</table>-->
 
-						<p><strong>Example response from retrieving an RDFSource :</strong></p>
+						<!--<p>-->
+							<!--<strong>Body (required)</strong>-->
+						<!--</p>-->
 
-						<p>Following is the response from retrieving a newly created RDFSource (from the &quot;Create&quot; example above).</p>
+						<!--<p>-->
+							<!--The RDFSource document is required in the entity body of the request. Following is an example RDFSource document-->
+							<!--in TRIG syntax. The syntax used for the body must match what you declare in the <code>Content-Type</code>-->
+							<!--header.-->
+						<!--</p>-->
 
-						<pre><code cpHighlight>
-					&lt;https://carbonldp.com/apps/rest-examples/persons/john-doe/&gt;&#123;
-						&lt;https://carbonldp.com/apps/rest-examples/persons/john-doe/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;http://www.base22.com/2016/05/ex#Person&gt; ;
-							&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;
-							&lt;https://carbonldp.com/ns/v1/platform#created&gt; &quot;2016-05-31T23:29:18.624Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
-							&lt;https://carbonldp.com/ns/v1/platform#modified&gt; &quot;2016-06-01T17:05:18.949Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
-							&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/~acl/&gt; ;
-							&lt;http://www.base22.com/2016/05/ex#firstName&gt; &quot;John&quot; ;
-							&lt;http://www.base22.com/2016/05/ex#lastName&gt; &quot;Doe&quot; ;
-							&lt;http://www.base22.com/2016/05/ex#phoneNumber&gt; &quot;(555) 555-5555&quot; ;
-							&lt;https://carbonldp.com/ns/v1/platform#defaultInteractionModel&gt; &lt;http://www.w3.org/ns/ldp#RDFSource&gt; .
-					&#125;
-					</code></pre>
+						<!--<pre><code cpHighlight class="turtle">-->
+						<!--@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.-->
+						<!--@prefix ex:&#60;http://www.base22.com/2016/05/ex#&#62;.-->
 
-						<p>
-							You may notice that additional properties are added to an RDFSource when it is created such as created, modified, and accessControlList. These are called <em>system managed
-							properties</em>, which Carbon adds automatically when you post new RDFSource documents.</p>
+						<!--&#60;&#62; &#123;-->
+							<!--&#60;&#62;-->
+								<!--a ldp:RDFSource, ex:Person;-->
+								<!--ex:firstName "John";-->
+								<!--ex:lastName "Doe";-->
+								<!--ex:phoneNumber "(555) 555-5555".-->
+						<!--&#125;-->
+						<!--</code></pre>-->
 
-						<p>You may also notice that, in addition to the type RDFSource, the resource is now also a BasicContainer. This is a convenient feature of Carbon LDP. When an RDFSource is
-							created, it is automatically treated also as container. Therefore, you can read an RDFSource as an RDFSource document and a container depending on the interaction model you
-							provide in the <code>Prefer</code> header of the GET request. If you're interested in the properties of the resource (as an entity), you should prefer the RDFSource
-							interaction model when you issue the GET request. If you're interested in the membership of the resource as a container, you should prefer the container interaction model
-							when you issue the GET request.
-						</p>
+						<!--<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>-->
 
-					</section>
+						<!--<p>If the optional <code>Slug</code> header is provided, the server will attempt to mint a URI for the document by-->
+							<!--appending the slug to the path. If the slug is not provided, the server will generate a random long number for the URI.-->
+						<!--</p>-->
+						<!--<p>The document's fully qualified URI will be returned by the <code>Location</code> header in the response. Whether or not the server mints the URI using a slug or random long-->
+							<!--number, the URI will always end with a trailing forward-slash.-->
+						<!--</p>-->
 
-					<section>
-						<h2>Update</h2>
+						<!--<p>An ETag header will also be returned, which can be used to determine if the document has changed since it was first created or last modified.</p>-->
 
-						<p>To update an existing RDFSource, issue a PUT request to the URI of the document to replace it with the document being submitted. A PUT request is a complete replacement of
-							the existing document; patching individual properties to change a document is not supported at this time.</p>
+						<!--<p><strong>Example request to create RDFSource :</strong></p>-->
 
-						<p>
-							<span class="ui blue horizontal label">PUT</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/&#123;rdfsource&#125;/</code>
-						</p>
+						<!--<pre><code cpHighlight class="turtle">-->
+						<!--POST /apps/rest-examples/persons/ HTTP/1.1-->
+						<!--Authorization: Basic-->
+						<!--Content-Type: application/trig-->
+						<!--Prefer: http://www.w3.org/ns/ldp#Container; rel=interaction-model-->
+						<!--Slug: john-doe-->
 
-						<table class="ui celled table">
-							<thead>
-								<tr>
-									<th>HTTP Header</th>
-									<th>Value</th>
-									<th colspan="1">Required?</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Authorization</td>
-									<td>Basic ...</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>Content-Type</td>
-									<td>
-										Either of:<br/>
-										<ul>
-											<li>text/turtle</li>
-											<li>application/ld+json</li>
-											<li>application/rdf+xml</li>
-											<li>application/trig</li>
-										</ul>
-									</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>Prefer</td>
-									<td><span class="nolink">http://www.w3.org/ns/ldp#RDFSource</span>; rel=interaction-model</td>
-									<td>Yes</td>
-								</tr>
-								<tr>
-									<td>If-Match</td>
-									<td>&#123;ETag value&#125;</td>
-									<td>Yes</td>
-								</tr>
-							</tbody>
-						</table>
+						<!--@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.-->
+						<!--@prefix ex:&lt;http://www.base22.com/2016/05/ex#&gt;.-->
 
-						<p><strong>Body (required)</strong></p>
-
-						<pre><code cpHighlight class="turtle">
-						&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; &#123;
-						&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;http://www.base22.com/2016/05/ex#Person&gt; ;
-							&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;
-							&lt;https://carbonldp.com/ns/v1/platform#created&gt; &quot;2016-05-31T23:29:18.624Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
-							&lt;https://carbonldp.com/ns/v1/platform#modified&gt; &quot;2016-06-01T17:05:18.949Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
-							&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/~acl/&gt; ;
-							&lt;http://www.base22.com/2016/05/ex#firstName&gt; &quot;John&quot; ;
-							&lt;http://www.base22.com/2016/05/ex#lastName&gt; &quot;Doe&quot; ;
-							&lt;http://www.base22.com/2016/05/ex#phoneNumber&gt; &quot;(555) 555-5555&quot; ;
-							&lt;https://carbonldp.com/ns/v1/platform#defaultInteractionModel&gt; &lt;http://www.w3.org/ns/ldp#RDFSource&gt; ;
-							&lt;http://www.base22.com/2016/05/ex#email&gt; &quot;john.doe@example.org&quot; .
-					&#125;
-					</code></pre>
-
-						<p>A successful update request will result in HTTP status code 200 OK.</p>
-						<p>
-							The best way to update an existing RDFSource document is to first retrieve it with a GET request and then modify what the server returned. This ensures that you will retain
-							any system managed properties that may have been added. Though system managed properties can not be changed by you, they must still exist in the document or the PUT request
-							will fail.
-						</p>
-						<p>Also required for a successful update is the If-Match header. It's value must match the ETag value obtained from a previous GET or HEAD request. This mechanism helps to
-							ensure that the document you're attempting to update has not been changed since you last retrieved it.</p>
+						        <!--a ldp:RDFSource, ex:Person;-->
+						        <!--ex:firstName "John";-->
+						        <!--ex:lastName "Doe";-->
+						        <!--ex:phoneNumber "(555) 555-5555".-->
+						<!--&#125;-->
+					<!--</code></pre>-->
 
 
-						<p><strong>Example request to update RDFSource :</strong></p>
+					<!--</section>-->
 
-						<pre><code cpHighlight>
-						PUT /apps/rest-examples/persons/john-doe/ HTTP/1.1
-						Authorization: Basic YWRtaW5AY2FyYm9ubGRwLmNvbTpoZWxsbw==
-						Prefer: http://www.w3.org/ns/ldp#RDFSource; rel=interaction-model
-						Content-Type: application/trig
-						If-Match: "429274222"
+					<!--<section>-->
+						<!--<h2>Retrieve</h2>-->
+						<!--<p>To retrieve an RDFSource, issue a GET request to the document's URI.</p>-->
 
-						&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; &#123;
-							&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;http://www.base22.com/2016/05/ex#Person&gt; ;
-								&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;
-								&lt;https://carbonldp.com/ns/v1/platform#created&gt; "2016-05-31T23:29:18.624Z"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
-								&lt;https://carbonldp.com/ns/v1/platform#modified&gt; "2016-06-01T17:05:18.949Z"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
-								&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/~acl/&gt; ;
-								&lt;http://www.base22.com/2016/05/ex#firstName&gt; "John" ;
-								&lt;http://www.base22.com/2016/05/ex#lastName&gt; "Doe" ;
-								&lt;http://www.base22.com/2016/05/ex#phoneNumber&gt; "(555) 555-5555" ;
-								&lt;https://carbonldp.com/ns/v1/platform#defaultInteractionModel&gt; &lt;http://www.w3.org/ns/ldp#RDFSource&gt; ;
-								&lt;http://www.base22.com/2016/05/ex#email&gt; "john.doe@example.org" .
-						&#125;
+						<!--<p>-->
+							<!--<span class="ui blue horizontal label">GET</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/&#123;rdfsource&#125;/</code>-->
+						<!--</p>-->
 
-					</code></pre>
+						<!--<table class="ui celled table">-->
+							<!--<thead>-->
+								<!--<tr>-->
+									<!--<th>HTTP Header</th>-->
+									<!--<th>Value</th>-->
+									<!--<th colspan="1">Required?</th>-->
+								<!--</tr>-->
+							<!--</thead>-->
+							<!--<tbody>-->
+								<!--<tr>-->
+									<!--<td>Authorization</td>-->
+									<!--<td>Basic ...</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Accept</td>-->
+									<!--<td>-->
+										<!--Either of:<br/>-->
+										<!--<ul>-->
+											<!--<li>text/turtle</li>-->
+											<!--<li>application/ld+json</li>-->
+											<!--<li>application/rdf+xml</li>-->
+											<!--<li>application/trig</li>-->
+										<!--</ul>-->
+									<!--</td>-->
+									<!--<td>No</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Prefer</td>-->
+									<!--<td><span class="nolink">http://www.w3.org/ns/ldp#RDFSource</span>; rel=interaction-model</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+							<!--</tbody>-->
+						<!--</table>-->
 
-					</section>
+						<!--<p>A successful request will result with HTTP status code 200 OK.</p>-->
 
-					<section>
-						<h2>Delete</h2>
+						<!--<p><strong>Example response from retrieving an RDFSource :</strong></p>-->
 
-						<p>To delete an RDFSource document, issue a DELETE request with an empty body to the URI of the document to be deleted.</p>
+						<!--<p>Following is the response from retrieving a newly created RDFSource (from the &quot;Create&quot; example above).</p>-->
 
-						<p>
-							<span class="ui blue horizontal label">DELETE</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/&#123;rdfsource&#125;/</code>
-						</p>
+						<!--<pre><code cpHighlight>-->
+					<!--&lt;https://carbonldp.com/apps/rest-examples/persons/john-doe/&gt;&#123;-->
+						<!--&lt;https://carbonldp.com/apps/rest-examples/persons/john-doe/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;http://www.base22.com/2016/05/ex#Person&gt; ;-->
+							<!--&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/platform#created&gt; &quot;2016-05-31T23:29:18.624Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/platform#modified&gt; &quot;2016-06-01T17:05:18.949Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/~acl/&gt; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#firstName&gt; &quot;John&quot; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#lastName&gt; &quot;Doe&quot; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#phoneNumber&gt; &quot;(555) 555-5555&quot; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/platform#defaultInteractionModel&gt; &lt;http://www.w3.org/ns/ldp#RDFSource&gt; .-->
+					<!--&#125;-->
+					<!--</code></pre>-->
 
-						<table class="ui celled table">
-							<thead>
-								<tr>
-									<th>HTTP Header</th>
-									<th>Value</th>
-									<th colspan="1">Required?</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>Authorization</td>
-									<td>Basic ...</td>
-									<td>Yes</td>
-								</tr>
-							</tbody>
-						</table>
+						<!--<p>-->
+							<!--You may notice that additional properties are added to an RDFSource when it is created such as created, modified, and accessControlList. These are called <em>system managed-->
+							<!--properties</em>, which Carbon adds automatically when you post new RDFSource documents.</p>-->
 
-						<p>A successful request will result with HTTP status code 200 OK.</p>
+						<!--<p>You may also notice that, in addition to the type RDFSource, the resource is now also a BasicContainer. This is a convenient feature of Carbon LDP. When an RDFSource is-->
+							<!--created, it is automatically treated also as container. Therefore, you can read an RDFSource as an RDFSource document and a container depending on the interaction model you-->
+							<!--provide in the <code>Prefer</code> header of the GET request. If you're interested in the properties of the resource (as an entity), you should prefer the RDFSource-->
+							<!--interaction model when you issue the GET request. If you're interested in the membership of the resource as a container, you should prefer the container interaction model-->
+							<!--when you issue the GET request.-->
+						<!--</p>-->
 
-						<p><strong>Example request to delete RDFSource :</strong></p>
+					<!--</section>-->
 
-						<pre><code cpHighlight>
-						DELETE /apps/rest-examples/persons/john-doe/ HTTP/1.1
-						Authorization: Basic
-					</code></pre>
+					<!--<section>-->
+						<!--<h2>Update</h2>-->
 
-					</section>
+						<!--<p>To update an existing RDFSource, issue a PUT request to the URI of the document to replace it with the document being submitted. A PUT request is a complete replacement of-->
+							<!--the existing document; patching individual properties to change a document is not supported at this time.</p>-->
+
+						<!--<p>-->
+							<!--<span class="ui blue horizontal label">PUT</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/&#123;rdfsource&#125;/</code>-->
+						<!--</p>-->
+
+						<!--<table class="ui celled table">-->
+							<!--<thead>-->
+								<!--<tr>-->
+									<!--<th>HTTP Header</th>-->
+									<!--<th>Value</th>-->
+									<!--<th colspan="1">Required?</th>-->
+								<!--</tr>-->
+							<!--</thead>-->
+							<!--<tbody>-->
+								<!--<tr>-->
+									<!--<td>Authorization</td>-->
+									<!--<td>Basic ...</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Content-Type</td>-->
+									<!--<td>-->
+										<!--Either of:<br/>-->
+										<!--<ul>-->
+											<!--<li>text/turtle</li>-->
+											<!--<li>application/ld+json</li>-->
+											<!--<li>application/rdf+xml</li>-->
+											<!--<li>application/trig</li>-->
+										<!--</ul>-->
+									<!--</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>Prefer</td>-->
+									<!--<td><span class="nolink">http://www.w3.org/ns/ldp#RDFSource</span>; rel=interaction-model</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+								<!--<tr>-->
+									<!--<td>If-Match</td>-->
+									<!--<td>&#123;ETag value&#125;</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+							<!--</tbody>-->
+						<!--</table>-->
+
+						<!--<p><strong>Body (required)</strong></p>-->
+
+						<!--<pre><code cpHighlight class="turtle">-->
+						<!--&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; &#123;-->
+						<!--&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;http://www.base22.com/2016/05/ex#Person&gt; ;-->
+							<!--&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/platform#created&gt; &quot;2016-05-31T23:29:18.624Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/platform#modified&gt; &quot;2016-06-01T17:05:18.949Z&quot;^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/~acl/&gt; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#firstName&gt; &quot;John&quot; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#lastName&gt; &quot;Doe&quot; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#phoneNumber&gt; &quot;(555) 555-5555&quot; ;-->
+							<!--&lt;https://carbonldp.com/ns/v1/platform#defaultInteractionModel&gt; &lt;http://www.w3.org/ns/ldp#RDFSource&gt; ;-->
+							<!--&lt;http://www.base22.com/2016/05/ex#email&gt; &quot;john.doe@example.org&quot; .-->
+					<!--&#125;-->
+					<!--</code></pre>-->
+
+						<!--<p>A successful update request will result in HTTP status code 200 OK.</p>-->
+						<!--<p>-->
+							<!--The best way to update an existing RDFSource document is to first retrieve it with a GET request and then modify what the server returned. This ensures that you will retain-->
+							<!--any system managed properties that may have been added. Though system managed properties can not be changed by you, they must still exist in the document or the PUT request-->
+							<!--will fail.-->
+						<!--</p>-->
+						<!--<p>Also required for a successful update is the If-Match header. It's value must match the ETag value obtained from a previous GET or HEAD request. This mechanism helps to-->
+							<!--ensure that the document you're attempting to update has not been changed since you last retrieved it.</p>-->
+
+
+						<!--<p><strong>Example request to update RDFSource :</strong></p>-->
+
+						<!--<pre><code cpHighlight>-->
+						<!--PUT /apps/rest-examples/persons/john-doe/ HTTP/1.1-->
+						<!--Authorization: Basic YWRtaW5AY2FyYm9ubGRwLmNvbTpoZWxsbw==-->
+						<!--Prefer: http://www.w3.org/ns/ldp#RDFSource; rel=interaction-model-->
+						<!--Content-Type: application/trig-->
+						<!--If-Match: "429274222"-->
+
+						<!--&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; &#123;-->
+							<!--&lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;http://www.base22.com/2016/05/ex#Person&gt; ;-->
+								<!--&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;-->
+								<!--&lt;https://carbonldp.com/ns/v1/platform#created&gt; "2016-05-31T23:29:18.624Z"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;-->
+								<!--&lt;https://carbonldp.com/ns/v1/platform#modified&gt; "2016-06-01T17:05:18.949Z"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;-->
+								<!--&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;https://dev.carbonldp.com/apps/rest-examples/persons/john-doe/~acl/&gt; ;-->
+								<!--&lt;http://www.base22.com/2016/05/ex#firstName&gt; "John" ;-->
+								<!--&lt;http://www.base22.com/2016/05/ex#lastName&gt; "Doe" ;-->
+								<!--&lt;http://www.base22.com/2016/05/ex#phoneNumber&gt; "(555) 555-5555" ;-->
+								<!--&lt;https://carbonldp.com/ns/v1/platform#defaultInteractionModel&gt; &lt;http://www.w3.org/ns/ldp#RDFSource&gt; ;-->
+								<!--&lt;http://www.base22.com/2016/05/ex#email&gt; "john.doe@example.org" .-->
+						<!--&#125;-->
+
+					<!--</code></pre>-->
+
+					<!--</section>-->
+
+					<!--<section>-->
+						<!--<h2>Delete</h2>-->
+
+						<!--<p>To delete an RDFSource document, issue a DELETE request with an empty body to the URI of the document to be deleted.</p>-->
+
+						<!--<p>-->
+							<!--<span class="ui blue horizontal label">DELETE</span> <code>/apps/&#123;app-name&#125;/&#123;container&#125;/&#123;rdfsource&#125;/</code>-->
+						<!--</p>-->
+
+						<!--<table class="ui celled table">-->
+							<!--<thead>-->
+								<!--<tr>-->
+									<!--<th>HTTP Header</th>-->
+									<!--<th>Value</th>-->
+									<!--<th colspan="1">Required?</th>-->
+								<!--</tr>-->
+							<!--</thead>-->
+							<!--<tbody>-->
+								<!--<tr>-->
+									<!--<td>Authorization</td>-->
+									<!--<td>Basic ...</td>-->
+									<!--<td>Yes</td>-->
+								<!--</tr>-->
+							<!--</tbody>-->
+						<!--</table>-->
+
+						<!--<p>A successful request will result with HTTP status code 200 OK.</p>-->
+
+						<!--<p><strong>Example request to delete RDFSource :</strong></p>-->
+
+						<!--<pre><code cpHighlight>-->
+						<!--DELETE /apps/rest-examples/persons/john-doe/ HTTP/1.1-->
+						<!--Authorization: Basic-->
+					<!--</code></pre>-->
+
+					<!--</section>-->
 
 				</article>
 			</main>
@@ -357,7 +364,7 @@
 
 		</div>
 
-		<sidebar-component [mobile]="false" [parentElement]="element" [contentReady]="contentReady" class="four wide computer only four wide tablet only column"></sidebar-component>
+		<!--<sidebar-component [mobile]="false" [parentElement]="element" [contentReady]="contentReady" class="four wide computer only four wide tablet only column"></sidebar-component>-->
 
 	</div>
 

--- a/src/app/website/documentation/rest-api/rdf-source.view.html
+++ b/src/app/website/documentation/rest-api/rdf-source.view.html
@@ -3,9 +3,9 @@
 		<div class="sixteen wide column">
 
 			<div class="ui breadcrumb">
-				<span class="section">Documentation</span>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
 				<i class="right chevron icon divider"></i>
-				<span class="section">REST API</span>
+				<a class="section" [routerLink]="[ '../rest-api' ]">REST API</a>
 				<i class="right arrow icon divider"></i>
 				<div class="active section">RDF Source</div>
 			</div>

--- a/src/app/website/documentation/rest-api/rest-api.view.html
+++ b/src/app/website/documentation/rest-api/rest-api.view.html
@@ -2,8 +2,9 @@
 	<div class="ui center aligned grid description">
 		<div class="ui container" id="rest-api">
 			<div class="ui breadcrumb">
-				<span class="section" [routerLink]="['..']">Documentation</span>
+				<a class="section" [routerLink]="[ '..' ]">Documentation</a>
 				<i class="right chevron icon divider"></i>
+				<div class="active section">REST API</div>
 			</div>
 			<div class="ui header"><img class="ui small left floated image" src="assets/images/ico-rest-150x150.gif">
 				<h2>REST API</h2></div>

--- a/src/app/website/header/header.component.html
+++ b/src/app/website/header/header.component.html
@@ -23,8 +23,8 @@
 
 						<div class="divider"></div>
 						<a class="home" [routerLink]="[ '/documentation/rest-api' ]">REST API</a>
-						<a class="item" [routerLink]="[ '/documentation/rest-api-getting-started' ]">Getting Started with the REST API</a>
-						<a class="item" [routerLink]="[ '/documentation/rest-api-object-model' ]">REST API Object Model</a>
+						<a class="item" [routerLink]="[ '/documentation/rest-api-getting-started' ]">Getting Started</a>
+						<a class="item" [routerLink]="[ '/documentation/rest-api-object-model' ]">Object Model</a>
 
 						<div class="divider"></div>
 						<a class="item" [routerLink]="[ '/documentation' ]">More...</a>

--- a/src/app/website/header/header.component.html
+++ b/src/app/website/header/header.component.html
@@ -98,8 +98,8 @@
 
 					<div class="divider"></div>
 					<a class="home" [routerLink]="[ '/documentation/rest-api' ]">REST API</a>
-					<a class="item" [routerLink]="[ '/documentation/rest-api-getting-started' ]">Getting Started with the REST API</a>
-					<a class="item" [routerLink]="[ '/documentation/rest-api-obect-model' ]">REST API Object Model</a>
+					<a class="item" [routerLink]="[ '/documentation/rest-api-getting-started' ]">Getting Started</a>
+					<a class="item" [routerLink]="[ '/documentation/rest-api-obect-model' ]">Object Model</a>
 					<div class="divider"></div>
 					<a class="home" [routerLink]="[ '/documentation/javascript-sdk' ]">JavaScript SDK</a>
 					<a class="item" [routerLink]="[ '/documentation/javascript-sdk-getting-started' ]">Getting Started</a>


### PR DESCRIPTION
 - Complete #88 standardize documentation styles and messages
 - Modify first icon for gitter rooms in community and support view
 - Modify abstract content in community and support view
 - Modify rdf-source.html to show not yet documented message
 - Modify header labels for REST API
 - Standardize different aspects of documentation pages: 
  - Abstract message box
  - Breadcrumbs
  - Not yet documented message
