### PR TITLE
Fix #149 - Broken image in Quick Start Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 1.1.1 (2017/04/13)
-
-- Fixed #149 - Broken image in Quick Start Guide
-
 # 1.1.0 (2017/03/30)
 
 - Completed #142 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1 (2017/04/13)
+
+- Fixed #149 - Broken image in Quick Start Guide
+
 # 1.1.0 (2017/03/30)
 
 - Completed #142 

--- a/source/documentation/quick-start-guide/index.ejs
+++ b/source/documentation/quick-start-guide/index.ejs
@@ -245,7 +245,7 @@ script: quick-start-guide
         the left-hand sidebar menu as shown below.</p>
 
 
-    <p><img class="ui bordered image" src="/assets/images/click-apps-in-workbench.jpg" alt="Click Apps in the Workbench left-hand sidebar menu."/></p>
+    <p><img class="ui bordered image" src="/assets/images/click-apps-in-workbench.png" alt="Click Apps in the Workbench left-hand sidebar menu."/></p>
 
     <p>Next, click the "Create app" button as shown below...</p>
 


### PR DESCRIPTION
- Fixed #149 - Broken image in Quick Start Guide