### PR TITLE
# 1.1.2 (2017/04/13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.2 (2017/04/13)
+
+- Fixed #151 - Quick Start Guide still lists angular2-carbonldp but links to angular-carbonldp
+    - Also changed reference to angular2-jspm-carbonldp-boilerplate to the newer angular-carbonldp-boilerplate.
+
 # 1.1.0 (2017/03/30)
 
 - Completed #142 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# 1.1.2 (2017/04/13)
-
-- Fixed #151 - Quick Start Guide still lists angular2-carbonldp but links to angular-carbonldp
-    - Also changed reference to angular2-jspm-carbonldp-boilerplate to the newer angular-carbonldp-boilerplate.
-
 # 1.1.0 (2017/03/30)
 
 - Completed #142 

--- a/source/documentation/quick-start-guide/index.ejs
+++ b/source/documentation/quick-start-guide/index.ejs
@@ -293,11 +293,11 @@ script: quick-start-guide
                 the REST API that you can do with the JavaScript SDK. However, the REST API is for lower-level programming that is generally more tedious than using the
                 JavaScript SDK. Most developers prefer to work primarily with the JavaScript SDK.
             </li>
-            <li><strong><a href="https://github.com/CarbonLDP/angular2-carbonldp">angular2-carbonldp</a></strong> - helper classes that simplify the integration between Angular
+            <li><strong><a href="https://github.com/CarbonLDP/angular-carbonldp">angular-carbonldp</a></strong> - helper classes that simplify the integration between Angular
                 and CarbonLDP.
             </li>
-            <li><strong><a href="https://github.com/CarbonLDP/angular2-jspm-carbon-boilerplate">angular2-jspm-carbon-boilerplate</a></strong> - Boilerplate project to use as a
-                starting point for building applications with Carbon, Angular, and JSPM.
+            <li><strong><a href="https://github.com/CarbonLDP/angular-carbonldp-boilerplate">angular-carbonldp-boilerplate</a></strong> - Boilerplate project to use as a
+                starting point for building applications with Angular 2/4 + CarbonLDP.
             </li>
             <li><strong><a href="https://github.com/CarbonLDP/carbon-typescript-boilerplate">carbon-typescript-boilerplate</a></strong> - Boilerplate project that shows how to
                 setup a TypeScript application with the Carbon LDP SDK.


### PR DESCRIPTION
- Fixed #151 - Quick Start Guide still lists angular2-carbonldp but links to angular-carbonldp
    - Also changed reference to angular2-jspm-carbonldp-boilerplate to the newer angular-carbonldp-boilerplate.