### PR TITLE
Bugfix/ldp 115 remove cloud references

### DIFF
--- a/.idea/libraries/tsconfig_roots.xml
+++ b/.idea/libraries/tsconfig_roots.xml
@@ -1,6 +1,7 @@
 <component name="libraryTable">
   <library name="tsconfig$roots" type="javaScript">
     <CLASSES />
+    <JAVADOC />
     <SOURCES />
   </library>
 </component>

--- a/.idea/libraries/tsconfig_roots.xml
+++ b/.idea/libraries/tsconfig_roots.xml
@@ -1,7 +1,6 @@
 <component name="libraryTable">
   <library name="tsconfig$roots" type="javaScript">
     <CLASSES />
-    <JAVADOC />
     <SOURCES />
   </library>
 </component>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Source code for [carbonldp.com](https://carbonldp.com)
 
 ### Important Notes for Contributors
 
-- Do not manually modify the CHANGELOG.md file. In our workflow, this is the responsibility of the manager when accepting and merging the pull request.
+- Do not manually modify the CHANGELOG.md file. In our workflow, this is the responsibility of the manager when accepting and merging a pull request.
 
 ### File Structure
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,9 @@ Source code for [carbonldp.com](https://carbonldp.com)
 3. Write your content in markdown ( https://guides.github.com/features/mastering-markdown/ )
 4. Add an excerpt, place a comment `<!-- more -->` the post excerpt will be from the beginning to where the comment was place.
 
-### Important Notes for Contributors
-
-- Do not manually modify the CHANGELOG.md file. In our workflow, this is the responsibility of the manager when accepting and merging a pull request.
-
 ### File Structure
+
+TODO: Describe each file/directory
 
     .
     ├── .idea                               
@@ -54,3 +52,7 @@ Source code for [carbonldp.com](https://carbonldp.com)
 	├── package.json
 	├── README.md
     └── semantic.json
+    
+### Contributing
+
+- Please read [our conventions and GitHub workflow](https://github.com/CarbonLDP/carbonldp/wiki/GitHub-conventions-and-workflow-for-Carbon-LDP)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Source code for [carbonldp.com](https://carbonldp.com)
 3. run `gulp build`
 4. run `hexo server` to serve the static site (the actual generated site goes in carbonldp-website/public)
 
-### Create a post
+### Create a new blog post
 
-1. run `hexo new post post-file-name`, a new file wil be added to source/_posts folder
+1. run `hexo new post post-file-name`, a new file will be added to source/_posts folder
 2. In the front-matter (https://hexo.io/docs/front-matter.html) of the post file change or add:
 	- title
 	- author (optional)
@@ -26,3 +26,31 @@ Source code for [carbonldp.com](https://carbonldp.com)
 3. Write your content in markdown ( https://guides.github.com/features/mastering-markdown/ )
 4. Add an excerpt, place a comment `<!-- more -->` the post excerpt will be from the beginning to where the comment was place.
 
+### Important Notes for Contributors
+
+- Do not manually modify the CHANGELOG.md file. In our workflow, this is the responsibility of the manager when accepting and merging the pull request.
+
+### File Structure
+
+    .
+    ├── .idea                               
+    ├── build                               
+    ├── carbonldp-panel                     
+    ├── hooks                       
+    ├── node_modules                        
+    ├── public                       
+    ├── scaffolds                         
+    ├── server                        
+    ├── source
+    ├── themes                       
+    ├── .gitignore 
+	├── .travis.yml
+	├── _config.yml
+	├── CHANGELOG.md
+	├── db.json
+	├── Dockerfile
+	├── gulpfile.js
+	├── LICENSE
+	├── package.json
+	├── README.md
+    └── semantic.json

--- a/source/documentation/essential-concepts/index.ejs
+++ b/source/documentation/essential-concepts/index.ejs
@@ -6,7 +6,7 @@ icon: ico-books.svg
 date: 2017-01-27 16:43:28
 sidebar: disabled
 documents:
-- title: Linked data concepts
+- title: Linked Data Concepts
   link: linked-data-concepts
   summary: General overview of the basic idea behind Linked Data and why it can make your applications more powerful.
 ---

--- a/source/documentation/essential-concepts/index.ejs
+++ b/source/documentation/essential-concepts/index.ejs
@@ -6,7 +6,7 @@ icon: ico-books.svg
 date: 2017-01-27 16:43:28
 sidebar: disabled
 documents:
-- title: Linked Data Concepts
+- title: Linked Data concepts
   link: linked-data-concepts
   summary: General overview of the basic idea behind Linked Data and why it can make your applications more powerful.
 ---

--- a/source/documentation/rest-api/getting-started/index.ejs
+++ b/source/documentation/rest-api/getting-started/index.ejs
@@ -25,11 +25,11 @@ date: 2017-02-07 19:01:07
 	<p>In this guide, we'll use the REST API to create a simple, but useful taxonomy service. A taxonomy is a controlled vocabulary of terms, organized in a hierarchy, that can be used for classifying and organizing information. Taxonomies are commonly used in web applications. Their terms are used for tagging content and as facets to help users filter and find. In this guide, you'll learn some of the the most important functions of the REST API as well as fundamental Linked Data Platform concepts. You'll also have a useful application that you can use to create and manage a single 'canonical' source of terms such as a corporate enterprise taxonomy. Other applications will be able to consume and use the taxonomy service using the same API.</p>
 	<p>We'll use the following steps to complete the application:</p>
 	<ol>
-		<li>Create a User Account</li>
-		<li>Create an Application</li>
-		<li>Model the Application (Vocabulary, Resources, Containers)</li>
-		<li>Create Application Resources</li>
-		<li>Secure the Application</li>
+		<li>Create a user account</li>
+		<li>Create an application</li>
+		<li>Model the application (vocabulary, resources, containers)</li>
+		<li>Create application resources</li>
+		<li>Secure the application</li>
 	</ol>
 	<p>Since this guide focuses on the REST API, you'll need a tool that can help you create and send HTTP requests. We recommend <a href="https://www.getpostman.com/">Postman</a>.
 		It's a great tool, it's free, and it's the one we'll be featuring in this guide. But feel free to use the tool you're most comfortable with. <br> <br>

--- a/source/documentation/rest-api/getting-started/index.ejs
+++ b/source/documentation/rest-api/getting-started/index.ejs
@@ -21,7 +21,7 @@ date: 2017-02-07 19:01:07
 </div>
 
 <section class="mainContent-section">
-	<h2 class="ui header">About the example application</h2>
+	<h2 class="ui header">About the Example Application</h2>
 	<p>In this guide, we'll use the REST API to create a simple, but useful taxonomy service. A taxonomy is a controlled vocabulary of terms, organized in a hierarchy, that can be used for classifying and organizing information. Taxonomies are commonly used in web applications. Their terms are used for tagging content and as facets to help users filter and find. In this guide, you'll learn some of the the most important functions of the REST API as well as fundamental Linked Data Platform concepts. You'll also have a useful application that you can use to create and manage a single 'canonical' source of terms such as a corporate enterprise taxonomy. Other applications will be able to consume and use the taxonomy service using the same API.</p>
 	<p>We'll use the following steps to complete the application:</p>
 	<ol>
@@ -32,11 +32,10 @@ date: 2017-02-07 19:01:07
 		<li>Secure the Application</li>
 	</ol>
 	<p>Since this guide focuses on the REST API, you'll need a tool that can help you create and send HTTP requests. We recommend <a href="https://www.getpostman.com/">Postman</a>.
-		It's a great tool,
-		it's free, and it's the one we'll be featuring in this guide. But feel free to use the tool you're most comfortable with. <br> <br>
+		It's a great tool, it's free, and it's the one we'll be featuring in this guide. But feel free to use the tool you're most comfortable with. <br> <br>
 		<img src="/assets/images/postman-logo.png" width="197" height="68">
 	</p>
-	<p><em><strong>Note:</strong> This guide assumes the typical host and port for a local dev environment,  <code>localhost:8080</code>. If your host and port differs, you'll need to make adjustments when using the given examples.</em></p>
+	<p><em><strong>Note:</strong> This guide assumes the typical host and port for a local dev environment,  <code>localhost:8083</code>. If your host and port differs, you'll need to make adjustments when using the given examples.</em></p>
 </section>
 
 
@@ -47,7 +46,7 @@ date: 2017-02-07 19:01:07
 	<section class="mainContent-subSection">
 		<h3 class="ui header">Create the Request</h3>
 		<p>Create the following HTTP request to create a platform account.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/platform/agents/</code></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/platform/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -59,7 +58,7 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -75,14 +74,15 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
-			@prefix vcard:&#60;http://www.w3.org/2001/vcard-rdf/3.0#&#62;.
-
-			<>
-				a cs:Agent;
-				cs:name "Jane Doe";
-				vcard:email "jane.doe@example.org";
-				cs:password "jane123".
+			@prefix cs:&lt;https://carbonldp.com/ns/v1/security#&gt;.
+			@prefix vcard:&lt;http://www.w3.org/2001/vcard-rdf/3.0#&gt;.
+			&lt;&gt;{
+			    &lt;&gt;
+			        a cs:Agent;
+			        cs:name "Jane Doe";
+			        vcard:email "jane.doe@example.org";
+			        cs:password "jane123".
+			}
 		</code></pre>
 	</section>
 
@@ -94,7 +94,7 @@ date: 2017-02-07 19:01:07
 				<i class="dropdown icon"></i> Content-Type
 			</div>
 			<div class="content">
-				<p>Since the request method is POST, the Content-Type HTTP header tells the platform what kind of content to expect in the body of the request. We use <a href="https://www.w3.org/TR/turtle/">Turtle (Terse RDF Triple Language)</a> in our documentation because it's brief and clean. Once you understand the Turtle syntax, you'll find that it's very easy to read and write. Note that Carbon also supports other content types for RDF such as:</p>
+				<p>Since the request method is POST, the Content-Type HTTP header tells the platform what kind of content to expect in the body of the request. We use the <a href="https://www.w3.org/TR/trig/">TriG</a> RDF Dataset Language (<code>application/trig</code>) because it's brief and also supports named graphs. Once you understand the TriG language, you'll find that it's relatively easy to read and write. Note that Carbon also supports other content types for RDF such as:</p>
 				<ul>
 					<li>Turtle: text/turtle</li>
 					<li>JSON-LD: application/ld+json</li>
@@ -119,13 +119,13 @@ date: 2017-02-07 19:01:07
 			<div class="content">
 				<p>The <code>Slug</code> header is intended to give the server a hint about how to mint a new URI for the resource being created. If a slug is not provided, Carbon will generate a random number when minting the URI. In this case, however, we're specifying a preference to use <code>jane-doe</code>. Therefore, if it is available for use, the server will mint the following URI:
 				</p>
-				<p><code>http://&lt;host&gt;/platform/agents/jane-doe/</code></p>
+				<p><code>http://localhost:8083/platform/agents/jane-doe/</code></p>
 			</div>
 			<div class="title">
 				<i class="dropdown icon"></i> Body
 			</div>
 			<div class="content">
-				<p>The body of the request is an RDF graph of triples written in Turtle, which we told the server we'd be using in the Content-Type header.</p>
+				<p>The body of the request is a graph of triples written in the RDF syntax matching the Content-Type header.</p>
 				<p>Using Turtle's @prefix directive we declare short prefix names so that we don't have to repeat long URIs in the triples that follow.</p>
 				<p>Following is a brief description of each of the required triples that come after the namespace declarations:</p>
 				<table class="ui celled table">
@@ -223,7 +223,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 				<tr>
 					<td>Location</td>
-					<td><span>http://&lt;host&gt;/platform/agents/jane-doe/</span></td>
+					<td><span>http://localhost:8083/platform/agents/jane-doe/</span></td>
 				</tr>
 			</tbody>
 		</table>
@@ -233,7 +233,7 @@ date: 2017-02-07 19:01:07
 		<h3 class="ui header">Examine the New Resource</h3>
 		<p>You can now examine the newly created resource by issuing a <code>GET</code> request to the URI that was minted for it.</p>
 		<p>Create the following HTTP request to get the Platform Agent.</p>
-		<p><span class="ui blue horizontal label">GET</span> <code>http://&lt;host&gt;/platform/agents/jane-doe/</code></p>
+		<p><span class="ui blue horizontal label">GET</span> <code>http://localhost:8083/platform/agents/jane-doe/</code></p>
 		<p>Note the trailing slash in the URI. An RDFSource created in Carbon is automatically also a Container (a feature Carbon manages for you), so the
 			server-minted URI always ends with a trailing slash.</p>
 		<p>You will need to authorize the request using the username and password of the agent that was defined in the body of the former POST request. Both the username and
@@ -251,7 +251,7 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<p>If you paste the URI in the address bar of your web browser and hit enter, for example, you should be prompted for the username and password. If you issue the request
-			with Postman or another tool, you should add Basic Auth to the request.<br/> <br/>Let's also add an Accept header to change the format of the response to JSON LD.
+			with Postman or another tool, you should add Basic Auth to the request.<br/> <br/>Let's also add an Accept header to see the response in JSON-LD.
 		</p>
 		<table class="ui celled table">
 			<thead>
@@ -264,7 +264,7 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -277,84 +277,105 @@ date: 2017-02-07 19:01:07
 		<p><strong>200 OK</strong></p>
 		<pre><code class="json">
 			[
-			   &#123;
-			      "@graph":[
-			         &#123;
-			            "@id":"http://&lt;host&gt;/platform/agents/jane-doe/",
-			            "@type":[
-			               "http://www.w3.org/ns/ldp#BasicContainer",
-			               "http://www.w3.org/ns/ldp#RDFSource",
-			               "http://www.w3.org/ns/ldp#Container",
-			               "https://carbonldp.com/ns/v1/security#Agent"
-			            ],
-			            "http://www.w3.org/2001/vcard-rdf/3.0#email":[
-			               &#123;
-			                  "@value":"jane.doe@example.org"
-			               &#125;
-			            ],
-			            "http://www.w3.org/ns/ldp#hasMemberRelation":[
-			               &#123;
-			                  "@id":"http://www.w3.org/ns/ldp#member"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/platform#created":[
-			               &#123;
-			                  "@type":"http://www.w3.org/2001/XMLSchema#dateTime",
-			                  "@value":"2015-11-13T22:28:46.101Z"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/platform#defaultInteractionModel":[
-			               &#123;
-			                  "@id":"http://www.w3.org/ns/ldp#RDFSource"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/platform#modified":[
-			               &#123;
-			                  "@type":"http://www.w3.org/2001/XMLSchema#dateTime",
-			                  "@value":"2015-11-13T22:28:46.101Z"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/security#enabled":[
-			               &#123;
-			                  "@type":"http://www.w3.org/2001/XMLSchema#boolean",
-			                  "@value":"true"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/security#name":[
-			               &#123;
-			                  "@value":"Jane Doe"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/security#password":[
-			               &#123;
-			                  "@value":"6bdabc50688f615775a82963ce381ab5df8be9447cb4a806b1cd8d919e1174bb"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/security#platformRole":[
-			               &#123;
-			                  "@id":"http://&lt;host&gt;/platform/roles/app-developer/"
-			               &#125;
-			            ],
-			            "https://carbonldp.com/ns/v1/security#salt":[
-			               &#123;
-			                  "@value":"ot8lotu5vb9r0siuqb7ip2ep8j"
-			               &#125;
-			            ]
-			         &#125;
-			      ],
-			      "@id":"http://&lt;host&gt;/platform/agents/jane-doe/"
-			   &#125;
+			  {
+			    "@graph": [
+			      {
+			        "@id": "http://localhost:8083/platform/agents/jane-doe/",
+			        "@type": [
+			          "http://www.w3.org/ns/ldp#BasicContainer",
+			          "https://carbonldp.com/ns/v1/security#ProtectedDocument",
+			          "http://www.w3.org/ns/ldp#Container",
+			          "http://www.w3.org/ns/ldp#RDFSource",
+			          "https://carbonldp.com/ns/v1/security#Agent"
+			        ],
+			        "http://www.w3.org/2001/vcard-rdf/3.0#email": [
+			          {
+			            "@value": "jane.doe@example.org"
+			          }
+			        ],
+			        "http://www.w3.org/ns/ldp#contains": [
+			          {
+			            "@id": "http://localhost:8083/platform/agents/jane-doe/app-role-map/"
+			          }
+			        ],
+			        "http://www.w3.org/ns/ldp#hasMemberRelation": [
+			          {
+			            "@id": "http://www.w3.org/ns/ldp#member"
+			          }
+			        ],
+			        "http://www.w3.org/ns/ldp#member": [
+			          {
+			            "@id": "http://localhost:8083/platform/agents/jane-doe/app-role-map/"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/platform#appRoleMap": [
+			          {
+			            "@id": "http://localhost:8083/platform/agents/jane-doe/app-role-map/"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/platform#created": [
+			          {
+			            "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+			            "@value": "2017-04-18T18:06:09.735Z"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/platform#defaultInteractionModel": [
+			          {
+			            "@id": "http://www.w3.org/ns/ldp#RDFSource"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/platform#modified": [
+			          {
+			            "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+			            "@value": "2017-04-18T18:06:09.735Z"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/security#accessControlList": [
+			          {
+			            "@id": "http://localhost:8083/platform/agents/jane-doe/~acl/"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/security#enabled": [
+			          {
+			            "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+			            "@value": "true"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/security#name": [
+			          {
+			            "@value": "Jane Doe"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/security#password": [
+			          {
+			            "@value": "09bc4d3bdd320919b7d0c486e165bf2d7a0c4ae2dd43d55df03937f0f3006e5c"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/security#platformRole": [
+			          {
+			            "@id": "http://localhost:8083/platform/roles/app-developer/"
+			          }
+			        ],
+			        "https://carbonldp.com/ns/v1/security#salt": [
+			          {
+			            "@value": "i5e0o8u0mkr65uvnfi9ltbjfnt"
+			          }
+			        ]
+			      }
+			    ],
+			    "@id": "http://localhost:8083/platform/agents/jane-doe/"
+			  }
 			]
 		</code></pre>
+		<p>JSON-LD is great response format to process JavaScript, but as you can see, it can be a tad verbose. You can issue the same <code>GET</code> request using <code>application/trig</code> or any other supported RDF syntax for the <code>Accept</code> header.</p>
 	</section>
 </section>
 <section class="mainContent-section">
 	<h2 class="ui header">Create an Application</h2>
 	<p>With your newly created platform account, you can now create an Application.</p>
 	<p>To create an application, issue the following request. Be sure to use your own unique name for the Slug or omit the Slug. You should also provide a unique name for the
-		application in the
-		body of the request.</p>
-	<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/platform/apps/</code></p>
+		application in the body of the request.</p>
+	<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/platform/apps/</code></p>
 	<table class="ui celled table">
 		<thead>
 			<tr>
@@ -366,7 +387,7 @@ date: 2017-02-07 19:01:07
 		<tbody>
 			<tr>
 				<td>Authorization</td>
-				<td>Basic ...</td>
+				<td>Basic (jane.doe@example.org, jane123)</td>
 				<td>Yes</td>
 			</tr>
 			<tr>
@@ -376,7 +397,7 @@ date: 2017-02-07 19:01:07
 			</tr>
 			<tr>
 				<td>Content-Type</td>
-				<td>text/turtle</td>
+				<td>application/trig</td>
 				<td>Yes</td>
 			</tr>
 			<tr>
@@ -388,24 +409,27 @@ date: 2017-02-07 19:01:07
 	</table>
 	<p><strong>Body (required)</strong></p>
 	<pre><code class="turtle">
-		@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
+		@prefix c:	&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+		@prefix cs:	&lt;https://carbonldp.com/ns/v1/security#&gt;.
 
-		<>
-			a cs:Application;
-			cs:name "Taxonomy Hub".
+		&lt;&gt;{
+		    &lt;&gt;
+		        a cs:Application;
+		        cs:name "Taxonomy Hub".
+		}
 	</code></pre>
 	<p>Issue the POST request.</p>
-	<p>A successful request will result in HTTP status code 201 Created. It will also respond with the server-minted URI for the Application resource, which in the case of our example is:</p>
-	<p><code>http://&lt;host&gt;/platform/apps/taxonomy-hub/</code></p>
+	<p>A successful request will result in HTTP status code <code>201 Created</code>. It will also respond with the server-minted <code>Location</code> URI for the Application resource, which in the case of our example is:</p>
+	<p><code>http://localhost:8083/platform/apps/taxonomy-hub/</code></p>
 	<section class="mainContent-subSection">
 		<h3 class="ui header">Examine the Application Root Container</h3>
-		<p>You can always verify a newly created resource by issuing a GET request to its URI, but it's important to keep in mind that the URI created for the Application only references the metadata resource for your application. When a new Application is created, Carbon also creates an access point at the following URI:</p>
-		<p><code>http://&lt;host&gt;/apps/&lt;app-slug&gt;/</code></p>
+		<p>You can always verify a newly created resource by issuing a GET request to its <code>Location</code> URI, but it's important to keep in mind that the URI created for the Application only references the metadata resource for your application. When a new Application is created, Carbon also creates an access point at the following URI:</p>
+		<p><code>http://localhost:8083/apps/&lt;app-slug&gt;/</code></p>
 		<p>So, in the case of our example, the application's access point or root URI would be:</p>
-		<p><code>http://&lt;host&gt;/apps/taxonomy-hub/</code></p>
-		<p>The difference between this URI and the URI of the Application metadata resource is the absence of the /platform segment after the host name.</p>
+		<p><code>http://localhost:8083/apps/taxonomy-hub/</code></p>
+		<p>The difference between this access point URI and the URI of the Application metadata resource is the absence of the <code>/platform</code> segment after the host name.</p>
 		<p>Issue the following request to examine the root container that Carbon created for you.</p>
-		<p><span class="ui blue horizontal label">GET</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/</code></p>
+		<p><span class="ui blue horizontal label">GET</span> <code>http://localhost:8083/apps/taxonomy-hub/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -417,34 +441,37 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<td>Accept</td>
+					<td>application/trig</td>
+					<td>No</td>
+				</tr>
+				<tr>
 					<td>Prefer</td>
-					<td><span class="nolink">http://www.w3.org/ns/ldp#Container</span>; rel=interaction-model</td>
-					<td>Yes</td>
+					<td><span class="nolink">http://www.w3.org/ns/ldp#RDFSource</span>; rel=interaction-model</td>
+					<td>No</td>
 				</tr>
 			</tbody>
 		</table>
-		<p>Notice that this time, since we did not specify an Accept header of type <code>application/ld+json</code>, the response we'll get back will be in the default Turtle syntax. While JSON-LD is often easiest to process with JavaScript, you will typically find Turtle to be a little more compact and easier to read.</p>
 		<p><strong>Example root container for an app</strong></p>
 		<pre><code class="turtle">
-			&#60;https://local.carbonldp.com/apps/taxonomy-hub/&#62;
-				a
-					&#60;http://www.w3.org/ns/ldp#RDFSource&#62; ,
-					&#60;http://www.w3.org/ns/ldp#Container&#62; ,
-					&#60;http://www.w3.org/ns/ldp#BasicContainer&#62; ;
-				&#60;http://www.w3.org/ns/ldp#member&#62;
-					&#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/&#62; ,
-					&#60;https://local.carbonldp.com/apps/taxonomy-hub/agents/&#62; ,
-					&#60;https://local.carbonldp.com/apps/taxonomy-hub/auth-tokens/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/platform#created&#62; "2016-04-01T11:58:03.543-05:00"^^&#60;http://www.w3.org/2001/XMLSchema#dateTime&#62; ;
-
-				&#60;http://www.w3.org/ns/ldp#hasMemberRelation&#62; &#60;http://www.w3.org/ns/ldp#member&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#accessControlList&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/~acl/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/platform#modified&#62; "2016-04-01T11:58:03.543-05:00"^^&#60;http://www.w3.org/2001/XMLSchema#dateTime&#62; .
+			&lt;http://localhost:8083/apps/taxonomy-hub/&gt; {
+				&lt;http://localhost:8083/apps/taxonomy-hub/&gt; a &lt;http://www.w3.org/ns/ldp#BasicContainer&gt; , &lt;http://www.w3.org/ns/ldp#Container&gt; , &lt;http://www.w3.org/ns/ldp#RDFSource&gt; , &lt;https://carbonldp.com/ns/v1/security#ProtectedDocument&gt; ;
+					&lt;http://www.w3.org/ns/ldp#contains&gt; &lt;http://localhost:8083/apps/taxonomy-hub/agents/&gt; , &lt;http://localhost:8083/apps/taxonomy-hub/auth-tickets/&gt; , &lt;http://localhost:8083/apps/taxonomy-hub/auth-tokens/&gt; , &lt;http://localhost:8083/apps/taxonomy-hub/roles/&gt; ;
+					&lt;http://www.w3.org/ns/ldp#hasMemberRelation&gt; &lt;http://www.w3.org/ns/ldp#member&gt; ;
+					&lt;http://www.w3.org/ns/ldp#member&gt; &lt;http://localhost:8083/apps/taxonomy-hub/agents/&gt; , &lt;http://localhost:8083/apps/taxonomy-hub/auth-tickets/&gt; , &lt;http://localhost:8083/apps/taxonomy-hub/auth-tokens/&gt; , &lt;http://localhost:8083/apps/taxonomy-hub/roles/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/platform#created&gt; "2017-04-18T20:01:52.104Z"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
+					&lt;https://carbonldp.com/ns/v1/platform#modified&gt; "2017-04-18T20:01:52.104Z"^^&lt;http://www.w3.org/2001/XMLSchema#dateTime&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#accessControlList&gt; &lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; .
+			}
 		</code></pre>
+		<p><strong>Example root container for an app</strong></p>
+		<p>Although this guide is all about using the REST API, you can still also use the Carbon LDP Workbench to verify your data. Now, for example, you can login to the workbench using the example user <code>jane.doe@example.org</code> with password, <code>jane123</code>. You should see the newly created Taxonomy Hub application in the list of applications as shown below.</p>
+		<img class="ui fluid image" src="/assets/images/workbench-taxonomy-hub-app.jpg" alt="Newly created app in Workbench">
+		<p><em>Note: Since the app was created through the REST API and not directly through the Workbench, you may not be able to use the Document Explorer until you edit the app in the Workbench, give it a description, and turn on the Allow all origins option.</em></p>
 	</section>
 </section>
 
@@ -472,7 +499,7 @@ date: 2017-02-07 19:01:07
 
 	<section class="mainContent-subSection">
 		<h3 class="ui header">Re-Using an Established Linked Data Vocabulary Called SKOS</h3>
-		<p>It's always a best-practice to re-use established linked data vocabularies instead of inventing duplicates and, as it turns out, there's already a good vocabulary that fits the needs of our application. It's called <a href="https://www.w3.org/TR/skos-reference/">SKOS (Simple Knowledge Organization System)</a>. According to the <a href="https://www.w3.org/TR/skos-primer/">SKOS Primer</a>, it &quot;provides a model for expressing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, folksonomies, and other similar types of controlled vocabulary.&quot; Sounds right up our alley, doesn't it? When we investigate SKOS, we not only see that it will suit the needs of our app, but that it provides a lot of clues about how we should model everything.</p>
+		<p>It's always a best-practice to re-use established linked data vocabularies instead of inventing duplicates and, as it turns out, there's already a good vocabulary that fits the needs of our application. It's called <a href="http://www.w3.org/2004/02/skos/intro">SKOS (Simple Knowledge Organization System)</a>. According to the <a href="https://www.w3.org/TR/skos-primer/">SKOS Primer</a>, it &quot;provides a model for expressing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, folksonomies, and other similar types of controlled vocabulary.&quot; Sounds right up our alley, doesn't it? When we investigate SKOS, we not only see that it will suit the needs of our app, but that it provides a lot of clues about how we should model everything.</p>
 	</section>
 
 	<section class="mainContent-subSection">
@@ -486,7 +513,7 @@ date: 2017-02-07 19:01:07
 		</ol>
 		<p>So, there you can see, we already have the class that can represent a taxonomy term. This means that when we create resources that represent taxonomy terms, we simply need to assert that it's an rdf:type skos:Concept. For example:</p>
 		<p><code>&lt;Carbon-document-URI&gt; a skos:Concept.</code></p>
-		<p>(Remember, ' <code>a</code> ' in turtle is shorthand for <code>rdf:type</code> ).</p>
+		<p>(Remember, ' <code>a</code> ' in Turtle or TriG is shorthand for <code>rdf:type</code> ).</p>
 		<p><strong>skos:prefLabel</strong></p>
 		<p>A SKOS Concept can have a preferred lexical label, which will be useful in representing it in a user interface. We'll be able to define a label for a concept as shown below.</p>
 
@@ -509,7 +536,7 @@ date: 2017-02-07 19:01:07
 
 		<p><strong>skos:broader and skos:narrower (semantic relationships)</strong></p>
 
-		<p>The <code>skos:broader</code> and <code>skos:narrower</code> properties give us what we need to express hierarchical links between our concepts.</p>
+		<p>The <code>skos:broader</code> and <code>skos:narrower</code> properties give us what we need to express links between our concepts.</p>
 
 		<p>
 			To assert that one concept is broader in meaning (i.e. more general) than another, the <code>skos:broader</code> property is used. The <code>skos:narrower</code> property is used to assert the inverse, namely when one concept is narrower in meaning (i.e. more specific) than another. For example:</p>
@@ -545,17 +572,17 @@ date: 2017-02-07 19:01:07
 					&#60;carbon-document-uri&#62;,
 					&#60;carbon-document-uri&#62;.
 		</code></pre>
-		<p>We now have all that we need to for the classes and properties required for our app. Relationships (links) between some of these properties as well as between additional LDP properties will allow us to organize concepts in a hierarchy and within a taxonomy concept scheme.</p>
+		<p>We now have all that we need for the classes and properties required in our app. Relationships (links) between some of these properties as well as between additional LDP properties will allow us to organize concepts in a hierarchy and within a taxonomy concept scheme.</p>
 		<p>Before we move on, it's worth mentioning that prefixes we've used come from the following namespaces.</p>
 		<p><b>Namespaces used</b></p>
 		<pre><code class="turtle">
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
 			@prefix dct:&#60;http://purl.org/dc/terms/&#62;.
 		</code></pre>
-		<p>There's more to SKOS than what we've covered here, so if you're interested in learning more, the following are good reference resources:</p>
+		<p>There's more to SKOS than what we've covered here, so if you're interested in learning more, the following are good references:</p>
 		<ul>
 			<li><a href="http://www.w3.org/2004/02/skos/intro">Introduction to SKOS</a></li>
-			<li><a href="http://www.w3.org/TR/2009/NOTE-skos-primer-20090818/">SKOS Simple Knowledge Organization System Primer</a></li>
+			<li><a href="https://www.w3.org/TR/skos-primer/">SKOS Simple Knowledge Organization System Primer</a></li>
 			<li><a href="http://www.w3.org/TR/skos-reference/">SKOS Simple Knowledge Organization System Reference</a></li>
 		</ul>
 	</section>
@@ -603,13 +630,11 @@ date: 2017-02-07 19:01:07
 			</li>
 		</ul>
 		<p>Though Carbon enforces no restriction on doing this, there are a few reasons why we might not want to.</p>
-		<p>First, as the depth of your taxonomy increases, so too does the length of your concept URIs. We should keep in mind that the fully qualified URI for each concept will
-			also include the
-			host and the base URI to the app. In this model, just one level deeper from the top concept could produce the following URI:</p>
-		<p><code>http://&lt;host&gt;/platform/apps/taxonomy-hub/topics/technology/javascript</code></p>
+		<p>First, as the depth of your taxonomy increases, so too does the length of your concept URIs. In this model, just one level deeper from the top concept could produce the following URI:</p>
+		<p><code>http://localhost:8083/platform/apps/taxonomy-hub/topics/technology/javascript/</code></p>
 		<p>You can see how the addition of just a few more levels could lengthen the URI significantly.</p>
 		<p>Another possible problem is that it creates a tight coupling between the URI for each concept and the location of the concept in a hierarchy. When you move categories around, you'd have to revise the URIs for several other concepts to keep the implication in tact. Furthermore, if you ever wanted to share concepts between branches of a taxonomy, or across multiple taxonomies, the implication of the URI would only be logical in one of the cases.</p>
-		<p>Finally, there is a more elegant approach for leveraging container behavior that can reduce the work required to manage the taxonomies.</p>
+		<p>Following is a more elegant approach for the container layout that can reduce the work required to manage taxonomies.</p>
 		<ul>
 			<li>taxonomy-hub/schemes/
 				<ul>
@@ -627,7 +652,7 @@ date: 2017-02-07 19:01:07
 			</li>
 		</ul>
 		<p>We've flattened things out a bit so that all concepts are direct children of the <code>topics/</code> container. We've also added a new container called <code>top-concepts/</code> to help us manage which concepts are root (top) concepts in the scheme.</p>
-		<p>As we work with this alternative approach, you'll begin to see why it's an improvement.</p>
+		<p>As we work with this approach, you'll begin to see why it's an improvement.</p>
 	</section>
 </section>
 
@@ -637,7 +662,7 @@ date: 2017-02-07 19:01:07
 		<h3 class="ui header">Create the schemes/ Container</h3>
 		<p>Let's start by creating the <code>schemes/</code> container. Since the application will always have only one <code>schemes/</code> container, this will be a one-time affair.</p>
 		<p>Create the following request.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/</code></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -649,12 +674,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -671,10 +696,12 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
 
-			&#60;&#62;
-				a ldp:BasicContainer.
+			&lt;&gt;{
+			    &lt;&gt;
+			        a ldp:BasicContainer.
+			}
 		</code></pre>
 
 		<p>We're specifying a Basic Container so that membership will automatically be recorded on the container when new schemes are posted, which will provide an easy way to list available schemes.</p>
@@ -684,8 +711,8 @@ date: 2017-02-07 19:01:07
 
 	<section class="mainContent-subSection">
 		<h3 class="ui header">Create Example Concept Scheme</h3>
-		<p>Now that we have the <code>schemes/</code> container, we can create one or more Concept Scheme containers within it. Since this is an action that would likely be repeated by end-users, it would make sense to incorporate the capability into a user interface. For now, however, let's be clear on what is required for the underlying HTTP request.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/</code></p>
+		<p>Now that we have the <code>schemes/</code> container, we can create one or more Concept Scheme containers within it. Since this is an action that would likely be repeated by end-users, it would make sense to incorporate the capability into a user interface. For now, however, let's be clear on what would be required for the underlying HTTP request.</p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -698,12 +725,12 @@ date: 2017-02-07 19:01:07
 
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -720,21 +747,23 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
-			@prefix dct:&#60;http://purl.org/dc/terms/&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
+			@prefix skos:&lt;http://www.w3.org/2004/02/skos/core#&gt;.
+			@prefix dct:&lt;http://purl.org/dc/terms/&gt;.
 
-			&#60;&#62;
-				a ldp:BasicContainer, skos:ConceptScheme;
-				ldp:memberOfRelation skos:inScheme;
-				dct:title "Topics".
+			&lt;&gt;{
+			    &lt;&gt;
+			        a ldp:BasicContainer, skos:ConceptScheme;
+			        ldp:memberOfRelation skos:inScheme;
+			        dct:title "Topics".
+			}
 		</code></pre>
 		<p>Take note of the following triple on the container:</p>
 		<p><code>&lt;&gt; ldp:memberOfRelation skos:inScheme</code></p>
 		<p>This configures the container to automatically add a link in each member that is added to the container. Whenever we POST a new concept into this scheme, Carbon will
 			automatically add the following triple to the concept document:</p>
-		<p><code>&lt;concept-uri&gt; skos:inScheme &lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/&gt;</code></p>
-		<p>Create and issue the request. A successful request should result in HTT status 201 Created.</p>
+		<p><code>&lt;concept-uri&gt; skos:inScheme &lt;http://localhost:8083/apps/taxonomy-hub/schemes/&gt;</code></p>
+		<p>Create and issue the request. A successful request should result in HTTP status <code>201 Created</code>.</p>
 		<p>This illustrates an interesting use of BasicContainer behavior. In the next step, we'll see another interesting use of container behavior with a DirectContainer.</p>
 	</section>
 
@@ -743,7 +772,7 @@ date: 2017-02-07 19:01:07
 		<p>As stated earlier, the <code>top-concepts/</code> container will give us an easy way to list the root concepts in a taxonomy. Our application should therefore create a <code>top-concepts/</code> container in every scheme created. You'd likely want to automate the creation of this container in the function that creates the scheme container, but for now, we'll do it by hand to complete the exercise. That is to say, for now, we're only supporting one concept scheme (taxonomy).</p>
 		<p>This time, we'll make use of a Direct Container. A Direct Container creates an access point that helps you manage membership triples in another container.</p>
 		<p>Create the following request.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -755,12 +784,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -782,22 +811,23 @@ date: 2017-02-07 19:01:07
 
 			&#60;&#62;
 				a ldp:DirectContainer;
-				ldp:membershipResource &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/&#62;;
+				ldp:membershipResource &#60;http://localhost:8083/apps/taxonomy-hub/schemes/topics/&#62;;
 				ldp:hasMemberRelation skos:hasTopConcept.
 		</code></pre>
-		<p>Notice, this time, we use the Prefer header to set the interaction model to RDF Source instead of Container. This keeps the <code>topics/</code> container that we're posting to from recognizing the <code>top-concepts/</code> container as a member. That is to say, it keeps it from recording a membership triple for the <code>top-concepts/</code> container. The outcome we want is for all concepts to be listed as members of the <code>topics/</code> container, but not the <code>top-concepts/</code> container.</p>
+		<p>Notice, this time, we use the Prefer header to set the interaction model to RDF Source instead of Container. This keeps the <code>topics/</code> container that we're posting to from recognizing the <code>top-concepts/</code> container as a member. That is to say, it keeps it from recording a membership triple for the <code>top-concepts/</code> container. The outcome we want is for all concepts to be listed as members of the <code>topics/</code> container, but not the <code>top-concepts/</code> container itself.</p>
 		<p>The <code>ldp:membershipResource</code> predicate of this Direct Container specifies an entirely different resource where membership triples should be written. Whenever we post to this container (the <code>top-concepts/</code> container), a membership triple will be written to the specified resource, which is the <code>topics/</code> container. In other words, if we later put a Concept to the <code>top-concepts/</code> container, that concept will become a member of the <code>topics/</code> container. Why would we want to do this? To understand, we have to consider the <code>ldp:hasMemberRelation</code> predicate, which is also used.</p>
 		<p>Whenever the <code>top-concepts/</code> container writes a membership triple to the container specified by <code>ldp:membershipResource</code> , it will use the predicate <code>skos:hasTopConcept</code> to represent that membership relationship because of what's defined by <code>ldp:hasMemberRelation</code> . This feature exists so that we can use a different vocabulary other than the standard LDP vocabulary to represent membership relations. When we post to <code>top-concepts/</code> , for example, the following statement will be added to the <code>topics/</code> container:</p>
-		<p><code>&lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/&gt; skos:hasTopConcept &lt;member-URI&gt;</code></p>
-		<p>We will not be posting to the <code>top-concepts/</code> container to create new documents. Instead, we'll post new concepts to the <code>topics/</code> container to create them and then later put the top concepts into the <code>top-concepts/</code> container. If you <em>post</em> a new resource to a container, the container creates a membership triple and a containment triple, but if you <em>put</em> an existing resource to a container, the container creates only a membership triple.</p>
+		<p><code>&lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/&gt; skos:hasTopConcept &lt;member-URI&gt;</code></p>
+		<p>We will not be posting to the <code>top-concepts/</code> container to create new documents. Instead, we'll post new concepts to the <code>topics/</code> container to create them and then later put the top concepts into the <code>top-concepts/</code> container. If you POST a new resource to a container, the container creates a membership triple and a containment triple, but if you PUT an existing resource to a container, the container creates only a membership triple.</p>
 		<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>
 	</section>
 
 	<section class="mainContent-section">
-		<h2 class="ui header">Create a Root Concept</h2>
-		<p>Now, we're ready to start creating concepts in our Topics taxonomy. This, of course, is a function that the GUI of our app would probably handle, but doing a few manually is important to this learning exercise.</p>
-		<p>For our first Concept, create the following request.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
+		<h2 class="ui header">Create the Top Concepts</h2>
+		<p>Now, we're ready to start creating concepts in our Topics taxonomy. This, of course, is a function that the GUI of our app would probably handle, but doing this manually is important to this learning exercise.</p>
+		<p><strong>Create the Top Concept, Design</strong></p>
+		<p>For our first Top Concept, Design, create the following request.</p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -809,12 +839,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -831,34 +861,26 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
+			@prefix skos:&lt;http://www.w3.org/2004/02/skos/core#&gt;.
 
-			&#60;&#62;
-				a ldp:BasicContainer, skos:Concept;
-				ldp:hasMemberRelation skos:narrower;
-				ldp:memberOfRelation skos:broader;
-				skos:prefLabel "Design"@en;
-				skos:prefLabel "DiseÃ±o"@es.
+			&lt;&gt;{
+				&lt;&gt;
+			        a ldp:BasicContainer, skos:Concept;
+			        ldp:hasMemberRelation skos:narrower;
+			        ldp:isMemberOfRelation skos:broader;
+			        skos:prefLabel "Design"@en;
+			        skos:prefLabel "DiseÃ±o"@es.
+			}
 		</code></pre>
-		<p>Notice, this time that the ldp:hasMemberRelation is skos:narrower. That means that any concept that is later PUT to this container will force a membership triple to be written on the container using <code>skos:narrower</code> as the predicate.</p>
-		<p>The <code>ldp:memberOfRelation</code> allows the inverse to be true. Any concept that is added to the membership of this container will get a triple written to it,
-			which defines this concept as its <code>skos:broader</code> concept. When we add the Information Architecture concept as a member, for example, the <code>information-architecture/</code> resource
-			will receive the following triple.</p>
+		<p>Notice, this time that the <code>ldp:hasMemberRelation</code> is <code>skos:narrower</code>. That means that any concept that is later PUT to this container will force a membership triple to be written on the container using <code>skos:narrower</code> as the predicate.</p>
+		<p>The <code>ldp:memberOfRelation</code> allows the inverse to be true. Any concept that is added to the membership of this container will get a triple written to it, which defines this concept as its <code>skos:broader</code> concept. When we add the Information Architecture concept as a member, for example, the <code>information-architecture/</code> resource will receive the following triple.</p>
 		<p><code>&lt;...topics/design/information-architecture/&gt; skos:broader &lt;......topics/design/&gt;</code></p>
-		<p>As we can see now, features of a container support what's needed to use the SKOS vocabulary. From any concept, we have a way to look both downwards and upwards in the hierarchy.</p>
-		<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>
-	</section>
-
-	<section class="mainContent-section">
-		<h2 class="ui header">Add Root Concepts as Member of the Scheme</h2>
-		<p>Now that the root concept is created, it is a member of its parent container. In other words, its parent container, <em>topics</em>, links to it with the following membership triple:</p>
-		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#member&gt; &lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
-		<p>Since the parent container is a Basic Container, the concept is also contained by it. The parent container expresses this relationship with the following containment triple:</p>
-		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#contains&gt; &lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
-		<p>What's needed now is to identify the root concept as a member of the topics scheme with the skos:hasTopConcept relation. This will be done when we PUT the concept to the top-concepts container.</p>
-		<p><span>Create the following request.</span></p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/top-concepts/</code></p>
+		<p>As we can see now, features of a container support what's needed to use the SKOS vocabulary. From any concept, we'll have a way to look both downwards and upwards in the hierarchy.</p>
+		<p>Issue the request. A successful response should provide the HTTP status code <code>201 Created</code>.</p>
+		<p><strong>Create the Top Concept, Technology</strong></p>
+		<p>In the same way, let's add the other top concept, Technology. Create and issue the following request.</p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -870,51 +892,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
-					<td>Yes</td>
-				</tr>
-				<tr>
-					<td>Prefer</td>
-					<td><span class="nolink">http://www.w3.org/ns/ldp#Container</span>; rel=interaction-model</td>
-					<td>Yes</td>
-				</tr>
-			</tbody>
-		</table>
-		<p><strong>Body (required)</strong></p>
-		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/&#62;.
-		</code></pre>
-		<p>Notice that the Carbon vocabulary is used. The class of the resource is a Carbon <code>AddMemberAction</code> with the specified member to add to the container we're putting it to.</p>
-		<p>Issue the request. A successful response should provide 200 OK.</p>
-		<p>Now, if you examine the <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code> container (GET), you'll see the membership triple link to the <code>design/</code> concept written as <code>skos:hasTopConcept</code>.</p>
-		<p>In the same way, let's add the other top concept, Technology. Create and issue the following request, which should result in the 201 Created status code.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
-		<table class="ui celled table">
-			<thead>
-				<tr>
-					<th>HTTP Header</th>
-					<th>Value</th>
-					<th colspan="1">Required?</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Authorization</td>
-					<td>Basic ...</td>
-					<td>Yes</td>
-				</tr>
-				<tr>
-					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -931,19 +914,30 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
+			@prefix skos:&lt;http://www.w3.org/2004/02/skos/core#&gt;.
 
-			&#60;&#62;
-			    a ldp:BasicContainer, skos:Concept;
-			    ldp:hasMemberRelation skos:narrower;
-			    ldp:memberOfRelation skos:broader;
-			    skos:prefLabel "Technology"@en;
-			    skos:prefLabel "Tecnología"@es.
+			&lt;&gt;{
+				&lt;&gt;
+			        a ldp:BasicContainer, skos:Concept;
+			        ldp:hasMemberRelation skos:narrower;
+			        ldp:isMemberOfRelation skos:broader;
+			        skos:prefLabel "Technology"@en;
+			        skos:prefLabel "Tecnologia"@es.
+			}
 		</code></pre>
-		<p>A successful POST should result in HTTP status 201 Created.</p>
-		<p>Again, identify this root concept as a member of the topics scheme with the skos:hasTopConcept relation, which is done when we PUT the concept to the top-concepts container.</p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/top-concepts/</code></p>
+		<p>A successful POST should result in HTTP status <code>201 Created</code>.</p>
+	</section>
+
+	<section class="mainContent-section">
+		<h2 class="ui header">Add Top Concepts as Members of the Scheme</h2>
+		<p>Now that the root concepts are created, they are members of their parent container. For example, the parent container, <code>topics</code>, links to <code>design/</code> with the following membership triple:</p>
+		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#member&gt; &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
+		<p>Since the parent container is a Basic Container, the concept is also contained by it. The parent container expresses this relationship with the following containment triple:</p>
+		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#contains&gt; &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
+		<p>What's needed now is to identify the concept as a member of the topics scheme with the <code>skos:hasTopConcept</code> relation. This will be done when we PUT the two concepts to the <code>top-concepts/</code> container, which can be done in a single HTTP request.</p>
+		<p><span>Create the following request.</span></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/top-concepts/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -955,12 +949,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -972,17 +966,25 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/technology/&#62;.
+			@prefix c:&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+			&lt;&gt;{
+				_:b0
+			        a c:AddMemberAction;
+			        c:targetMember &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/design/&gt;,
+			            &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/technology/&gt;.
+			}
 		</code></pre>
-		<p>A successful PUT should result in HTTP status 200 OK.</p>
-		<p>Next, let's create one of the second-level concepts, Information Architecture (Concept 1.1), which is a narrower concept of the Design top concept we already created.
-			Create and issue
-			the following request.</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
+		<p>Notice that the Carbon vocabulary is used. The class of the resource is a Carbon <code>AddMemberAction</code> with the specified members to add to the container we're putting it to.</p>
+		<p>Issue the request. A successful response should provide <code>200 OK</code>.</p>
+		<p>Now, if you examine the <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code> container (GET), you'll see the membership triples link to the <code>design/</code> and <code>technology/</code> concepts written as <code>skos:hasTopConcept</code>.</p>
+	</section>
+
+	<section class="mainContent-section">
+			<h2 class="ui header">Add Additional Concepts</h2>
+
+		<p>Next, let's create one of the second-level concepts, Information Architecture (Concept 1.1), which is a narrower concept of the Design top concept we already created. Create and issue the following request.</p>
+
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -994,12 +996,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1016,57 +1018,21 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
+			@prefix skos:&lt;http://www.w3.org/2004/02/skos/core#&gt;.
 
-			&#60;&#62;
-				a ldp:BasicContainer, skos:Concept;
-				ldp:hasMemberRelation skos:narrower;
-				ldp:memberOfRelation skos:broader;
-				skos:prefLabel "Information Architecture".
+			&lt;&gt;{
+				&lt;&gt;
+			        a ldp:BasicContainer, skos:Concept;
+			        ldp:hasMemberRelation skos:narrower;
+			        ldp:isMemberOfRelation skos:broader;
+			        skos:prefLabel "Information Architecture".
+			}
 		</code></pre>
-		<p>A successful POST should result in HTTP status 201 Created.</p>
-		<p>Next, we must make <span>Information Architecture (Concept 1.1) a narrower concept of Design (Concept 1) by adding it to the Design concept's container membership.</span></p>
-		<p><span>Create and issue the following request:</span></p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/</code></p>
-		<table class="ui celled table">
-			<thead>
-				<tr>
-					<th>HTTP Header</th>
-					<th>Value</th>
-					<th colspan="1">Required?</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Authorization</td>
-					<td>Basic ...</td>
-					<td>Yes</td>
-				</tr>
-				<tr>
-					<td>Content-Type</td>
-					<td>text/turtle</td>
-					<td>Yes</td>
-				</tr>
-				<tr>
-					<td>Prefer</td>
-					<td>http://www.w3.org/ns/ldp#Container; rel=interaction-model</td>
-					<td>Yes</td>
-				</tr>
-			</tbody>
-		</table>
-		<p><strong>Body (required)</strong></p>
-		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/information-architecture/&#62;.
-		</code></pre>
-		<p>If you examine the <code>design/</code> container now, you will see the membership triple for the <code>information-architecture/</code> container defined by <code>skos:narrower</code>. If you examine the information-architecture/ container, you will see skos:broader linking to its parent, design/. Great.</p>
-		<p>Finally, we will create concepts 2.1 and 2.2, and then make them members of the parent Concept 2.</p>
+		<p>A successful POST should result in HTTP status <code>201 Created</code>.</p>
 		<p><strong>Create Concept 2.1</strong></p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
+		<p>Next, let's create the HTML5 concept (Concept 2.1), which will be a narrower concept of the Technology top concept we already created. Create and issue the following request.</p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1078,12 +1044,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>apllication/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1100,17 +1066,21 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
+			@prefix skos:&lt;http://www.w3.org/2004/02/skos/core#&gt;.
 
-			&#60;&#62;
-				a ldp:BasicContainer, skos:Concept;
-				ldp:hasMemberRelation skos:narrower;
-				ldp:memberOfRelation skos:broader;
-				skos:prefLabel "HTML5".
+			&lt;&gt;{
+				&lt;&gt;
+			        a ldp:BasicContainer, skos:Concept;
+			        ldp:hasMemberRelation skos:narrower;
+			        ldp:isMemberOfRelation skos:broader;
+			        skos:prefLabel "HTML5".
+			}
 		</code></pre>
+		<p>A successful request will result in HTTP status code <code>201 Created</code>.</p>
+
 		<p><strong>Create Concept 2.2</strong></p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1122,12 +1092,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1144,34 +1114,40 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
-			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
+			@prefix ldp:&lt;http://www.w3.org/ns/ldp#&gt;.
+			@prefix skos:&lt;http://www.w3.org/2004/02/skos/core#&gt;.
 
-			&#60;&#62;
-				a ldp:BasicContainer, skos:Concept;
-				ldp:hasMemberRelation skos:narrower;
-				ldp:memberOfRelation skos:broader;
-				skos:prefLabel "JavaScript".
+			&lt;&gt;{
+				&lt;&gt;
+			        a ldp:BasicContainer, skos:Concept;
+			        ldp:hasMemberRelation skos:narrower;
+			        ldp:isMemberOfRelation skos:broader;
+			        skos:prefLabel "JavaScript".
+			}
 		</code></pre>
-		<p><strong>Add Concept 2.1 to membership of parent</strong></p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/technology/</code></p>
+		<p>A successful request will result in HTTP status code <code>201 Created</code>.</p>
+
+		<p><strong>Make Concept 1.1 Narrower</strong></p>
+		<p>Next, we must make <span>Information Architecture (Concept 1.1) a narrower concept of Design (Concept 1) by adding it to the Design concept's container membership.</span></p>
+		<p><span>Create and issue the following request:</span></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/design/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
 					<th>HTTP Header</th>
 					<th>Value</th>
-					<th>Required?</th>
+					<th colspan="1">Required?</th>
 				</tr>
 			</thead>
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1183,14 +1159,22 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/html5/&#62;.
+			@prefix c:&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+			&lt;&gt;{
+				_:b0
+			        a c:AddMemberAction;
+			        c:targetMember &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/information-architecture/&gt;.
+			}
 		</code></pre>
-		<p><strong>Add Concept 2.2 to membership of parent</strong></p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/technology/</code></p>
+		<p>A successful PUT request will result in HTTP status <code>200 OK</code>.</p>
+
+		<p>If you examine the <code>design/</code> container now, you will see the membership triple for the <code>information-architecture/</code> container defined by <code>skos:narrower</code>. If you examine the <code>information-architecture/</code> container, you will see <code>skos:broader</code> linking to its parent, <code>design/</code>. Great!</p>
+
+		<p><strong>Make Concepts 2.1 and 2.2 Narrower</strong></p>
+
+		<p>Similarly, we will make Concept 2.1 and 2.2 narrower than the parent Concept 2. Since both have the same parent, we can do this in a single request.</p>
+
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/topics/technology/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1202,12 +1186,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>apllication/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1219,12 +1203,15 @@ date: 2017-02-07 19:01:07
 		</table>
 		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;{{host}}/apps/taxonomy-hub/schemes/topics/javascript/&#62;.
+			@prefix c:&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+			&lt;&gt;{
+				_:b0
+			        a c:AddMemberAction;
+			        c:targetMember &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/html5/&gt;,
+			            &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/javascript/&gt;.
+			}
 		</code></pre>
+		<p>A successful PUT request will result in HTTP status <code>200 OK</code>.</p>
 	</section>
 </section>
 
@@ -1246,9 +1233,9 @@ date: 2017-02-07 19:01:07
 			<li><strong>user</strong> - Role for read-only operations.</li>
 		</ul>
 		<section class="mainContent-subSection">
-			<h4>Create the editor role</h4>
+			<h4>Create the Editor Role</h4>
 			<p>Issue the following HTTP request to create the editor role.</p>
-			<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/</code></p>
+			<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/</code></p>
 			<table class="ui celled table">
 				<thead>
 					<tr>
@@ -1260,12 +1247,12 @@ date: 2017-02-07 19:01:07
 				<tbody>
 					<tr>
 						<td>Authorization</td>
-						<td>Basic ...</td>
+						<td>Basic (jane.doe@example.org, jane123)</td>
 						<td>Yes</td>
 					</tr>
 					<tr>
 						<td>Content-Type</td>
-						<td>text/turtle</td>
+						<td>application/trig</td>
 						<td>Yes</td>
 					</tr>
 					<tr>
@@ -1281,19 +1268,24 @@ date: 2017-02-07 19:01:07
 				</tbody>
 			</table>
 			<pre><code class="turtle">
-				@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
-
-				&#60;&#62;
-				 a cs:AppRole;
-				    cs:name "editor";
-				    cs:description "Role for all available operations." .
+				@prefix cs:&lt;https://carbonldp.com/ns/v1/security#&gt;.
+				@prefix vcard:&lt;http://www.w3.org/2001/vcard-rdf/3.0#&gt;.
+				&lt;&gt;{
+				    &lt;&gt;
+				        a cs:AppRole;
+				        cs:name "editor";
+				        cs:description "Role for all available operations." .
+				}
 			</code></pre>
+
+			<p>A successful POST request results in HTTP status <code>201 Created</code>.</p>
+
 		</section>
 
 		<section class="mainContent-subSection">
-			<h4>Create the user role</h4>
+			<h4>Create the User Role</h4>
 			<p>Issue the following HTTP request to create the user role.</p>
-			<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/</code></p>
+			<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/</code></p>
 			<table class="ui celled table">
 				<thead>
 					<tr>
@@ -1305,12 +1297,12 @@ date: 2017-02-07 19:01:07
 				<tbody>
 					<tr>
 						<td>Authorization</td>
-						<td>Basic ...</td>
+						<td>Basic (jane.doe@example.org, jane123)</td>
 						<td>Yes</td>
 					</tr>
 					<tr>
 						<td>Content-Type</td>
-						<td>text/turtle</td>
+						<td>application/trig</td>
 						<td>Yes</td>
 					</tr>
 					<tr>
@@ -1326,23 +1318,28 @@ date: 2017-02-07 19:01:07
 				</tbody>
 			</table>
 			<pre><code class="turtle">
-				@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
-
-				&#60;&#62;
-				 a cs:AppRole;
-				    cs:name "user";
-				    cs:description "Role for read-only operations." .
+				@prefix cs:&lt;https://carbonldp.com/ns/v1/security#&gt;.
+				@prefix vcard:&lt;http://www.w3.org/2001/vcard-rdf/3.0#&gt;.
+				&lt;&gt;{
+				    &lt;&gt;
+				        a cs:AppRole;
+				        cs:name "user";
+				        cs:description "Role for read-only operations." .
+				}
 			</code></pre>
+
+			<p>A successful POST request results in HTTP status <code>201 Created</code>.</p>
+
 		</section>
 	</section>
 
 
 	<section class="mainContent-subSection">
 		<h3 class="ui header">Create Application Users</h3>
-		<p>For this exercise, we'll create just two users - one to add to the editor role and another to add to the user role.</p>
-		<h4>Create agent, testuser1</h4>
+		<p>For this exercise, we'll create just two users - one to add to the editor role and another to add to the user role. In Carbon, a user is also referred to as an <em>agent</em>.</p>
+		<h4>Create Agent, testuser1</h4>
 		<p>Issue the following HTTP request to create the first user (an Agent).</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/agents/</code></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1354,7 +1351,7 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1370,17 +1367,22 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
-			@prefix vcard:&#60;http://www.w3.org/2001/vcard-rdf/3.0#&#62;.
-
-			&#60;&#62;
-				a cs:Agent;
-			    vcard:email "user1@example.com" ;
-			    cs:password "password".
+			@prefix cs:&lt;https://carbonldp.com/ns/v1/security#&gt;.
+			@prefix vcard:&lt;http://www.w3.org/2001/vcard-rdf/3.0#&gt;.
+			&lt;&gt;{
+			    &lt;&gt;
+			        a cs:Agent;
+				    vcard:email "user1@example.com" ;
+			        cs:password "password".
+			}
 		</code></pre>
-		<h4>Create agent, testuser2</h4>
-		<p>Issue the following HTTP request to create the second user (an Agent).</p>
-		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/agents/</code></p>
+
+		<p>A successful POST request results in HTTP status <code>201 Created</code>.</p>
+
+
+		<h4>Create Agent, testuser2</h4>
+		<p>Issue the following HTTP request to create the second user (an agent).</p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1392,7 +1394,7 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1408,14 +1410,18 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
-			@prefix vcard:&#60;http://www.w3.org/2001/vcard-rdf/3.0#&#62;.
-
-			&#60;&#62;
-				a cs:Agent;
-			    vcard:email "user2@example.com" ;
-			    cs:password "password".
+			@prefix cs:&lt;https://carbonldp.com/ns/v1/security#&gt;.
+			@prefix vcard:&lt;http://www.w3.org/2001/vcard-rdf/3.0#&gt;.
+			&lt;&gt;{
+			    &lt;&gt;
+			        a cs:Agent;
+				    vcard:email "user2@example.com" ;
+				    cs:name "test user 2";
+			        cs:password "password".
+			}
 		</code></pre>
+
+		<p>A successful POST request results in HTTP status <code>201 Created</code>.</p>
 	</section>
 
 
@@ -1423,10 +1429,10 @@ date: 2017-02-07 19:01:07
 		<h3 class="ui header">Assign Users to Roles</h3>
 		<p>In Carbon a role is similar to a user group. Roles are resources that can have one or more agents (users) as members.
 			In this step, we will assign testuser1 to the Editor role and testuser2 to the User role. To add an agent to a role, we
-			put the agent to the membership of the <code>agents</code> container within the container that represents the role.</p>
-		<h4>Add testuser1 to the editor role</h4>
+			PUT the agent to the membership of the <code>agents</code> container that exists within the container of the role.</p>
+		<h4>Add Test User 1 to the Editor Role</h4>
 		<p>Issue the following HTTP request to add testuser1 to the editor role.</p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/editor/agents/</code></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/editor/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1438,12 +1444,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1454,15 +1460,17 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;{{protoocolAndHost}}/apps/taxonomy-hub/agents/testuser1/&#62;.
+			@prefix c:&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+			&lt;&gt;{
+				_:b0
+			        a c:AddMemberAction;
+			        c:targetMember &lt;http://localhost:8083/apps/taxonomy-hub/agents/testuser1/&gt;.
+			}
 		</code></pre>
-		<h4>Add testuser2 to the user role</h4>
+		<p>A successful PUT request results in HTTP status <code>200 OK</code>.</p>
+		<h4>Add Test User 2 to the User Role</h4>
 		<p>Issue the following HTTP request to add testuser2 to the user role.</p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/user/agents/</code></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/user/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1474,12 +1482,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1490,22 +1498,27 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/agents/testuser2/&#62;.
+			@prefix c:&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+			&lt;&gt;{
+				_:b0
+			        a c:AddMemberAction;
+			        c:targetMember &lt;http://localhost:8083/apps/taxonomy-hub/agents/testuser2/&gt;.
+			}
 		</code></pre>
+		<p>A successful PUT request results in HTTP status <code>200 OK</code>.</p>
 	</section>
 
 	<section class="mainContent-subSection">
 		<h3 class="ui header">Put the Roles into the Role-Hierarchy</h3>
+
 		<p>We'll need to give permissions to our roles on resources. But we cannot assign permissions for the roles yet because the roles have not been positioned in the role
 			hierarchy. Carbon has a role hierarchy so that permissions can be inherited from the parent in any place within the hierarchy. The hierarchy always starts at
-			<code>/apps/&lt;app-name&gt;/roles/app-admin/</code>. So, in order to be able to apply permissions (ACLs - Access Control List) on any resource, the roles that will
-			be part of an ACL will need to exist within the role hierarchy.</p>
-		<h4>Put the Editor Role into the Role Hierarchy/h4>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/app-admin/</code></p>
+			<code>/apps/&lt;app-name&gt;/roles/app-admin/</code>. So, in order to be able to apply permissions (ACLs - Access Control Lists) on any resource, the roles that will
+			be part of an ACL will need to exist within the role hierarchy. We can PUT both the Editor and User roles into to the role hierarchy with a single request.</p>
+
+		<h4>Put the Editor and User Roles into the Role Hierarchy</h4>
+
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/app-admin/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1517,12 +1530,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1533,57 +1546,19 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
+			@prefix c:&lt;https://carbonldp.com/ns/v1/platform#&gt;.
+			&lt;&gt;{
+				_:b0
+				    a c:AddMemberAction;
+				    c:targetMember &lt;/apps/taxonomy-hub/roles/editor/&gt;,
+						&lt;/apps/taxonomy-hub/roles/user/&gt;.
+			}
+		</code></pre>
+		<p>A successful PUT should result in HTTP status <code>200 OK</code>.</p>
+		<p>If you inspect, the <code>app-admin/</code> container, you should see the child roles linked with a triple like this:</p>
+		<p><code>&lt;http://localhost:8083/apps/taxonomy-hub/roles/app-admin/&gt; &lt;https://carbonldp.com/ns/v1/security#childRole&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/editor/&gt;</code></p>
 
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;/apps/taxonomy-hub/roles/editor/&#62;.
-		</code></pre>
-		<p>A successful PUT should result in HTTP status 200 OK.</p>
-		<p>If you inspect, the app-admin/ container, you should see the child role specified as follows:</p>
-		<p><code>&lt;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&gt; &lt;https://carbonldp.com/ns/v1/security#childRole&gt; &lt;https://local.carbonldp.com/apps/taxonomy-hub/roles/editor/&gt;</code></p>
-		<h4>Put the User Role into the Role Hierarchy</h4>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/app-admin/</code></p>
-		<table class="ui celled table">
-			<thead>
-				<tr>
-					<th><span>HTTP Header</span></th>
-					<th>Value</th>
-					<th>Required?</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Authorization</td>
-					<td>Basic ...</td>
-					<td>Yes</td>
-				</tr>
-				<tr>
-					<td>Content-Type</td>
-					<td>text/turtle</td>
-					<td>Yes</td>
-				</tr>
-				<tr>
-					<td>Prefer</td>
-					<td><span class="nolink">http://www.w3.org/ns/ldp#Container</span>; rel=interaction-model</td>
-					<td>Yes</td>
-				</tr>
-			</tbody>
-		</table>
-		<pre><code class="turtle">
-			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
-
-			_:b0
-				a c:AddMemberAction;
-				c:targetMember &#60;/apps/taxonomy-hub/roles/user/&#62;.
-		</code></pre>
-		<p>A successful PUT should result in HTTP status 200 OK.</p>
-		<p>If you inspect, the app-admin/ container, you should see the child role specified as follows:</p>
-		<pre><code class="turtle">
-			&#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&#62;
-				&#60;https://carbonldp.com/ns/v1/security#childRole&#62;
-					&#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/user/&#62;
-		</code></pre>
+		<p>Conversely, if you inspect either the child roles, you will see a link back to the parent <code>app-admin/</code> role by way of the property identified by the URI, <code>https://carbonldp.com/ns/v1/security#parentRole</code>.</p>
 	</section>
 	<section class="mainContent-subSection">
 
@@ -1595,7 +1570,7 @@ date: 2017-02-07 19:01:07
 		<p>Issue the following request to get the ACL for the application's root container, take notice that the interaction model used in this
 			request is RDFSource, as shown in the Prefer header.</p>
 
-		<p><span class="ui blue horizontal label">GET</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/~acl/</code></p>
+		<p><span class="ui blue horizontal label">GET</span> <code>http://localhost:8083/apps/taxonomy-hub/~acl/</code></p>
 
 		<table class="ui celled table">
 			<thead>
@@ -1608,78 +1583,103 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Prefer</td>
 					<td><span class="nolink">http://www.w3.org/ns/ldp#RDFSource</span>; rel=interaction-model</td>
 					<td>Yes</td>
+				</tr>
+				<tr>
+					<td>Accept</td>
+					<td>application/trig</td>
+					<td>No</td>
 				</tr>
 			</tbody>
 		</table>
 		<p>The resulting ACL is shown below.</p>
 		<pre><code class="turtle">
-			&#60;https://local.carbonldp.com/apps/taxonomy-hub/~acl/&#62;
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlList&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#accessTo&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#accessControlEntry&#62; _:node1af9bsvs3x2 ;
-				&#60;https://carbonldp.com/ns/v1/security#inheritableEntry&#62; _:node1af9bsvs3x3 .
+			&lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; {
+				&lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; a &lt;https://carbonldp.com/ns/v1/security#AccessControlList&gt; .
 
-			_:node1af9bsvs3x2
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlEntry&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subjectClass&#62; &#60;https://carbonldp.com/ns/v1/security#AppRole&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subject&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#permission&#62;
-					&#60;https://carbonldp.com/ns/v1/security#Read&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateAccessPoint&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Upload&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Extend&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Download&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#AddMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Update&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateChild&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#RemoveMember&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true ;
-				&#60;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&#62; "9292cddf-08f8-4d07-90f2-987951cc2a44" .
+				_:node1be13fi05x169 a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+					&lt;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&gt; "fb95eee6-b2c6-46a0-af0b-ac8b1d50bf25" ;
+					&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+					&lt;https://carbonldp.com/ns/v1/security#permission&gt; &lt;https://carbonldp.com/ns/v1/security#AddMember&gt; , &lt;https://carbonldp.com/ns/v1/security#CreateAccessPoint&gt; , &lt;https://carbonldp.com/ns/v1/security#CreateChild&gt; , &lt;https://carbonldp.com/ns/v1/security#Download&gt; , &lt;https://carbonldp.com/ns/v1/security#Extend&gt; , &lt;https://carbonldp.com/ns/v1/security#ManageSecurity&gt; , &lt;https://carbonldp.com/ns/v1/security#Read&gt; , &lt;https://carbonldp.com/ns/v1/security#RemoveMember&gt; , &lt;https://carbonldp.com/ns/v1/security#Update&gt; , &lt;https://carbonldp.com/ns/v1/security#Upload&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/app-admin/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
 
-			_:node1af9bsvs3x3
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlEntry&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subjectClass&#62; &#60;https://carbonldp.com/ns/v1/security#AppRole&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subject&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#permission&#62;
-					&#60;https://carbonldp.com/ns/v1/security#Read&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateAccessPoint&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Upload&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Extend&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Download&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#AddMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Update&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateChild&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#RemoveMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Delete&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true ;
-				&#60;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&#62; "735e1e37-c2c4-4ae4-81ed-99a41d5b4ced" .
+				&lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; &lt;https://carbonldp.com/ns/v1/security#accessTo&gt; &lt;http://localhost:8083/apps/taxonomy-hub/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#accessControlEntry&gt; _:node1be13fi05x169 ;
+					&lt;https://carbonldp.com/ns/v1/security#inheritableEntry&gt; _:node1be13fi05x170 .
+
+				_:node1be13fi05x170 a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+					&lt;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&gt; "70a3d1c2-5b65-435a-8717-e78d6f70512c" ;
+					&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+					&lt;https://carbonldp.com/ns/v1/security#permission&gt; &lt;https://carbonldp.com/ns/v1/security#AddMember&gt; , &lt;https://carbonldp.com/ns/v1/security#CreateAccessPoint&gt; , &lt;https://carbonldp.com/ns/v1/security#CreateChild&gt; , &lt;https://carbonldp.com/ns/v1/security#Download&gt; , &lt;https://carbonldp.com/ns/v1/security#Extend&gt; , &lt;https://carbonldp.com/ns/v1/security#ManageSecurity&gt; , &lt;https://carbonldp.com/ns/v1/security#Read&gt; , &lt;https://carbonldp.com/ns/v1/security#RemoveMember&gt; , &lt;https://carbonldp.com/ns/v1/security#Update&gt; , &lt;https://carbonldp.com/ns/v1/security#Upload&gt; , &lt;https://carbonldp.com/ns/v1/security#Delete&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/app-admin/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
+			}
 		</code></pre>
 		<p>
-			The ACL defines a <code>accessControlEntry</code> and an <code>inheritableEntry</code>, each linking to an <code>AccessControlEntry</code> by way of a blank nodes.
-			The entry linked by <code>accessControlEntry</code> defines access to the resource itself. The entry linked by <code>inheritableEntry</code> defines permissions
-			that can be inherited by child resources when the child resources do not override them.
+			The ACL defines an <code>accessControlEntry</code> and an <code>inheritableEntry</code>, each linking to an <code>AccessControlEntry</code> by way of a blank nodes. The entry linked by <code>accessControlEntry</code> defines access to the resource itself. The entry linked by <code>inheritableEntry</code> defines permissions that can be inherited by child resources when the child resources do not override them.
 		</p>
-		<h4>Give the Editor role all permissions and the user role READ permissions.</h4>
-		<p>The best way to modify permissions on a resource using the REST API is to start by getting the ACL for the resource as we've done here. We can then copy and
-			paste that ACL into a text editor, make some manual modifications, and then update the ACL.</p>
-		<p>For each role, repeat the following procedure.</p>
+
+		<h4>Give the Editor Role All Permissions and the User Role READ Permissions.</h4>
+		<p>The best way to modify permissions on a resource using the REST API is to start by getting the ACL for the resource as we've just done above. We can paste that ACL into a text editor, make some manual modifications, and then update it.</p>
+		<p>Doing this manually, is admittedly cumbersome, but it helps you understand how things work under the hood. For each of the roles (Editor and User), we'll need to repeat the following procedure using the ACL body copied from the step above.</p>
+
 		<ul>
-			<li>Copy an existing AccessControlEntry stanza and paste it at the bottom.
-			<li>Remove the <code>bNodeIdentifier</code> triple from the pasted stanza (Carbon will automatically generate a new one when we update the ACL).</li>
-			<li>Change the name of the blank node so that it is unique in the file.</li>
-			<li>Change the <code>security#subject</code> literal value to be the URI of the role that you are giving the permissions.</li>
-			<li>Add the new blank nodes to the <code>security#accessControlEntry</code> and <code>security#inheritableEntry</code> triples near the top.</li>
+			<li>Create a new AccessControlEntry in the RDF document.</li>
+			<li>Make sure the name of the blank node is unique.</li>
+			<li>Make sure the <code>security#subject</code> has the URI for the proper role that you are giving the permissions.</li>
+			<li>Add the new blank nodes to one or both of the <code>security#accessControlEntry</code> and <code>security#inheritableEntry</code> triples near the top.</li>
 		</ul>
-		<p>When you are done, you should end up with something similar to what is shown in the body of the following request. To update the ACL, you then issue a <code>PUT</code>
-			request to replace the ACL.</p>
-		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/~acl/</code></p>
+
+		<p>For example, add the following AccessControlEntry, which will put the Read permission on the <code>user/</code> role.</p>
+		<pre><code class="turtle">
+		_:user-ace a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+				&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+				&lt;https://carbonldp.com/ns/v1/security#permission&gt; &lt;https://carbonldp.com/ns/v1/security#Read&gt; ;
+				&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/user/&gt; ;
+				&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
+		</code></pre>
+		<p>Also add the following AccessControlEntry, which will put the several more permissions on the <code>editor/</code> role.</p>
+
+		<pre><code class="turtle">
+		_:editor-ace a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+			&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+			&lt;https://carbonldp.com/ns/v1/security#permission&gt;
+				&lt;https://carbonldp.com/ns/v1/security#AddMember&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#CreateAccessPoint&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#CreateChild&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#Download&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#Extend&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#ManageSecurity&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#Read&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#RemoveMember&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#Update&gt; ,
+				&lt;https://carbonldp.com/ns/v1/security#Upload&gt; ;
+			&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/editor/&gt; ;
+			&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
+		</code></pre>
+
+		<p>Finally, we can add the two new entries on both the <code>#accessControlEntry</code> and the <code>#inheritableEntry</code> properties as shown below.</p>
+
+		<pre><code class="turtle">
+		&lt;https://carbonldp.com/ns/v1/security#accessControlEntry&gt;
+			_:node1be13fi05x169 ,
+			_:editor-ace ,
+			_:user-ace ;
+		&lt;https://carbonldp.com/ns/v1/security#inheritableEntry&gt;
+			_:node1be13fi05x170 ,
+			_:editor-ace ,
+			_:user-ace .
+		</code></pre>
+
+		<p>When you are done, you should end up with something similar to what is shown in the body of the following request. To update the ACL, you then issue a <code>PUT</code>request to replace the ACL.</p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/~acl/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1691,12 +1691,12 @@ date: 2017-02-07 19:01:07
 			<tbody>
 				<tr>
 					<td>Authorization</td>
-					<td>Basic ...</td>
+					<td>Basic (jane.doe@example.org, jane123)</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
 					<td>Content-Type</td>
-					<td>text/turtle</td>
+					<td>application/trig</td>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -1707,75 +1707,77 @@ date: 2017-02-07 19:01:07
 			</tbody>
 		</table>
 		<pre><code class="turtle">
-			&#60;https://local.carbonldp.com/apps/taxonomy-hub/~acl/&#62;
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlList&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#accessTo&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#accessControlEntry&#62;
-					_:node1af9bsvs3x2,
-					_:abc,
-					_:xyz ;
-				&#60;https://carbonldp.com/ns/v1/security#inheritableEntry&#62;
-					_:node1af9bsvs3x3,
-					_:abc,
-					_:xyz .
+			&lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; {
+				&lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; a &lt;https://carbonldp.com/ns/v1/security#AccessControlList&gt; .
 
-			_:node1af9bsvs3x2
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlEntry&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subjectClass&#62; &#60;https://carbonldp.com/ns/v1/security#AppRole&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subject&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#permission&#62;
-					&#60;https://carbonldp.com/ns/v1/security#Read&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateAccessPoint&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Upload&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Extend&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Download&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#AddMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Update&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateChild&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#RemoveMember&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true ;
-				&#60;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&#62; "9292cddf-08f8-4d07-90f2-987951cc2a44" .
+				_:node1be13fi05x169 a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+					&lt;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&gt; "fb95eee6-b2c6-46a0-af0b-ac8b1d50bf25" ;
+					&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+					&lt;https://carbonldp.com/ns/v1/security#permission&gt;
+						&lt;https://carbonldp.com/ns/v1/security#AddMember&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#CreateAccessPoint&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#CreateChild&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Download&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Extend&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#ManageSecurity&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Read&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#RemoveMember&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Update&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Upload&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/app-admin/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
 
-			_:node1af9bsvs3x3
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlEntry&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subjectClass&#62; &#60;https://carbonldp.com/ns/v1/security#AppRole&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subject&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#permission&#62;
-					&#60;https://carbonldp.com/ns/v1/security#Read&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateAccessPoint&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Upload&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Extend&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Download&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#AddMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Update&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateChild&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#RemoveMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Delete&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true ;
-				&#60;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&#62; "735e1e37-c2c4-4ae4-81ed-99a41d5b4ced" .
+				&lt;http://localhost:8083/apps/taxonomy-hub/~acl/&gt; &lt;https://carbonldp.com/ns/v1/security#accessTo&gt; &lt;http://localhost:8083/apps/taxonomy-hub/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#accessControlEntry&gt;
+						_:node1be13fi05x169 ,
+						_:editor-ace ,
+						_:user-ace ;
+					&lt;https://carbonldp.com/ns/v1/security#inheritableEntry&gt;
+						_:node1be13fi05x170 ,
+						_:editor-ace ,
+						_:user-ace .
 
-			_:abc
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlEntry&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subjectClass&#62; &#60;https://carbonldp.com/ns/v1/security#AppRole&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subject&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/editor/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#permission&#62;
-					&#60;https://carbonldp.com/ns/v1/security#Read&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateAccessPoint&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Upload&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Extend&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Download&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#AddMember&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#Update&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#CreateChild&#62; ,
-					&#60;https://carbonldp.com/ns/v1/security#RemoveMember&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true .
+				_:node1be13fi05x170 a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+					&lt;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&gt; "70a3d1c2-5b65-435a-8717-e78d6f70512c" ;
+					&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+					&lt;https://carbonldp.com/ns/v1/security#permission&gt;
+						&lt;https://carbonldp.com/ns/v1/security#AddMember&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#CreateAccessPoint&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#CreateChild&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Download&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Extend&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#ManageSecurity&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Read&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#RemoveMember&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Update&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Upload&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Delete&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/app-admin/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
 
-			_:xyz
-				a &#60;https://carbonldp.com/ns/v1/security#AccessControlEntry&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subjectClass&#62; &#60;https://carbonldp.com/ns/v1/security#AppRole&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#subject&#62; &#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/user/&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#permission&#62; &#60;https://carbonldp.com/ns/v1/security#Read&#62; ;
-				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true .
+				_:user-ace a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+					&lt;https://carbonldp.com/ns/v1/security#permission&gt; &lt;https://carbonldp.com/ns/v1/security#Read&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/user/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
+
+				_:editor-ace a &lt;https://carbonldp.com/ns/v1/security#AccessControlEntry&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#granting&gt; true ;
+					&lt;https://carbonldp.com/ns/v1/security#permission&gt;
+						&lt;https://carbonldp.com/ns/v1/security#AddMember&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#CreateAccessPoint&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#CreateChild&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Download&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Extend&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#ManageSecurity&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Read&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#RemoveMember&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Update&gt; ,
+						&lt;https://carbonldp.com/ns/v1/security#Upload&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subject&gt; &lt;http://localhost:8083/apps/taxonomy-hub/roles/editor/&gt; ;
+					&lt;https://carbonldp.com/ns/v1/security#subjectClass&gt; &lt;https://carbonldp.com/ns/v1/security#AppRole&gt; .
+
+			}
 		</code></pre>
 		<p>A successful PUT should result in HTTP status <code>200 OK</code>.</p>
 	</section>
@@ -1783,5 +1785,5 @@ date: 2017-02-07 19:01:07
 
 <section class="mainContent-section">
 	<h2 class="ui header">Conclusion</h2>
-	<p>This guide described how to build an example application using the Carbon LDP REST API. Normally, developers will prefer use of the Carbon LDP Workbench (GUI) and the JavaScript SDK, which together simplify the process of building an app. Still, all functions of the platform can be accessed through the REST API and those developers who understand it may find its use to be advantageous in some cases.</p>
+	<p>This guide described how to build an example application using the Carbon LDP REST API. Normally, developers will prefer use of the Carbon LDP Workbench (GUI) and the JavaScript SDK, which together simplify the process of building an app. Still, all functions of the platform can be accessed through the REST API and those developers who understand the REST API may find it advantageous to use in some cases.</p>
 </section>

--- a/source/documentation/rest-api/getting-started/index.ejs
+++ b/source/documentation/rest-api/getting-started/index.ejs
@@ -5,7 +5,7 @@ description: Guide to get you started. How to build an example application using
 date: 2017-02-07 19:01:07
 ---
 
-<h1>Getting Started with the REST API</h1>
+<h1>Getting started with the REST API</h1>
 
 <div class="ui message">
 	<div class="content">
@@ -21,7 +21,7 @@ date: 2017-02-07 19:01:07
 </div>
 
 <section class="mainContent-section">
-	<h2 class="ui header">About the Example Application</h2>
+	<h2 class="ui header">About the example application</h2>
 	<p>In this guide, we'll use the REST API to create a simple, but useful taxonomy service. A taxonomy is a controlled vocabulary of terms, organized in a hierarchy, that can be used for classifying and organizing information. Taxonomies are commonly used in web applications. Their terms are used for tagging content and as facets to help users filter and find. In this guide, you'll learn some of the the most important functions of the REST API as well as fundamental Linked Data Platform concepts. You'll also have a useful application that you can use to create and manage a single 'canonical' source of terms such as a corporate enterprise taxonomy. Other applications will be able to consume and use the taxonomy service using the same API.</p>
 	<p>We'll use the following steps to complete the application:</p>
 	<ol>
@@ -40,11 +40,11 @@ date: 2017-02-07 19:01:07
 
 
 <section class="mainContent-section">
-	<h2 class="ui header">Create a User Account</h2>
+	<h2 class="ui header">Create a user account</h2>
 	<p>To interact with Carbon through the REST API, we'll need a user account. This can be done through the Workbench GUI, but since this is a guide on using the REST API, we'll do it by issuing a POST request through HTTP. The resource that comprises a Carbon account is known as an <em>Agent</em> - a <em>platform agent</em> to be precise. Later, you will learn about <em>application agents</em>, which represent accounts specifically for users of the applications you build.
 	</p>
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create the Request</h3>
+		<h3 class="ui header">Create the request</h3>
 		<p>Create the following HTTP request to create a platform account.</p>
 		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/platform/agents/</code></p>
 		<table class="ui celled table">
@@ -87,7 +87,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Review the Request</h3>
+		<h3 class="ui header">Review the request</h3>
 		<p>Before issuing this request, you may want to examine its parts. To get more information about each part in the request, click to expand an item of interest below.</p>
 		<div class="ui styled fluid accordion">
 			<div class="title">
@@ -205,7 +205,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Issue the Request</h3>
+		<h3 class="ui header">Issue the request</h3>
 		<p>Issue the POST request.</p>
 		<p>A successful request will result in HTTP status code 201 Created. The ETag header in the response will confirm the time of creation and the Location header will provide
 			the server minted URI for the new Agent resource. For example:</p>
@@ -230,7 +230,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Examine the New Resource</h3>
+		<h3 class="ui header">Examine the new resource</h3>
 		<p>You can now examine the newly created resource by issuing a <code>GET</code> request to the URI that was minted for it.</p>
 		<p>Create the following HTTP request to get the Platform Agent.</p>
 		<p><span class="ui blue horizontal label">GET</span> <code>http://localhost:8083/platform/agents/jane-doe/</code></p>
@@ -371,7 +371,7 @@ date: 2017-02-07 19:01:07
 	</section>
 </section>
 <section class="mainContent-section">
-	<h2 class="ui header">Create an Application</h2>
+	<h2 class="ui header">Create an application</h2>
 	<p>With your newly created platform account, you can now create an Application.</p>
 	<p>To create an application, issue the following request. Be sure to use your own unique name for the Slug or omit the Slug. You should also provide a unique name for the
 		application in the body of the request.</p>
@@ -422,7 +422,7 @@ date: 2017-02-07 19:01:07
 	<p>A successful request will result in HTTP status code <code>201 Created</code>. It will also respond with the server-minted <code>Location</code> URI for the Application resource, which in the case of our example is:</p>
 	<p><code>http://localhost:8083/platform/apps/taxonomy-hub/</code></p>
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Examine the Application Root Container</h3>
+		<h3 class="ui header">Examine the application root container</h3>
 		<p>You can always verify a newly created resource by issuing a GET request to its <code>Location</code> URI, but it's important to keep in mind that the URI created for the Application only references the metadata resource for your application. When a new Application is created, Carbon also creates an access point at the following URI:</p>
 		<p><code>http://localhost:8083/apps/&lt;app-slug&gt;/</code></p>
 		<p>So, in the case of our example, the application's access point or root URI would be:</p>
@@ -476,7 +476,7 @@ date: 2017-02-07 19:01:07
 </section>
 
 <section class="mainContent-section">
-	<h2 class="ui header">Model the Application (Vocabulary, Resources, Containers)</h2>
+	<h2 class="ui header">Model the application (vocabulary, resources, containers)</h2>
 	<p>Now that you have an application root created, you can begin to create RDF documents in the application. Before you start posting arbitrary RDF documents, however, it's a good idea to design a general model for the application. Answering the following questions can help you determine what the model should be.</p>
 	<ul>
 		<li>What entities will the resources in our application represent?</li>
@@ -498,12 +498,12 @@ date: 2017-02-07 19:01:07
 
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Re-Using an Established Linked Data Vocabulary Called SKOS</h3>
+		<h3 class="ui header">Re-using an established Linked Data vocabulary called SKOS</h3>
 		<p>It's always a best-practice to re-use established linked data vocabularies instead of inventing duplicates and, as it turns out, there's already a good vocabulary that fits the needs of our application. It's called <a href="http://www.w3.org/2004/02/skos/intro">SKOS (Simple Knowledge Organization System)</a>. According to the <a href="https://www.w3.org/TR/skos-primer/">SKOS Primer</a>, it &quot;provides a model for expressing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, folksonomies, and other similar types of controlled vocabulary.&quot; Sounds right up our alley, doesn't it? When we investigate SKOS, we not only see that it will suit the needs of our app, but that it provides a lot of clues about how we should model everything.</p>
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Mini SKOS Primer</h3>
+		<h3 class="ui header">Mini SKOS primer</h3>
 		<p><strong>skos:Concept</strong></p>
 		<p>SKOS introduces the class <code>skos:Concept</code> , which allows implementors to assert that a given resource is a concept. This is done in two steps:</p>
 		<ol>
@@ -588,7 +588,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Consider the Role of LDP Containers</h3>
+		<h3 class="ui header">Consider the role of LDP containers</h3>
 		<p>It may seem intuitive to model the container behavior for our application in such way that each concept is a container to its narrower concepts. Or, in other words, so
 			that
 			narrower concepts
@@ -657,9 +657,9 @@ date: 2017-02-07 19:01:07
 </section>
 
 <section class="mainContent-section">
-	<h2 class="ui header">Create Application Resources</h2>
+	<h2 class="ui header">Create application resources</h2>
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create the schemes/ Container</h3>
+		<h3 class="ui header">Create the schemes/ container</h3>
 		<p>Let's start by creating the <code>schemes/</code> container. Since the application will always have only one <code>schemes/</code> container, this will be a one-time affair.</p>
 		<p>Create the following request.</p>
 		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/</code></p>
@@ -710,7 +710,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create Example Concept Scheme</h3>
+		<h3 class="ui header">Create example concept scheme</h3>
 		<p>Now that we have the <code>schemes/</code> container, we can create one or more Concept Scheme containers within it. Since this is an action that would likely be repeated by end-users, it would make sense to incorporate the capability into a user interface. For now, however, let's be clear on what would be required for the underlying HTTP request.</p>
 		<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/schemes/</code></p>
 		<table class="ui celled table">
@@ -823,7 +823,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-section">
-		<h2 class="ui header">Create the Top Concepts</h2>
+		<h2 class="ui header">Create the top concepts</h2>
 		<p>Now, we're ready to start creating concepts in our Topics taxonomy. This, of course, is a function that the GUI of our app would probably handle, but doing this manually is important to this learning exercise.</p>
 		<p><strong>Create the Top Concept, Design</strong></p>
 		<p>For our first Top Concept, Design, create the following request.</p>
@@ -930,7 +930,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-section">
-		<h2 class="ui header">Add Top Concepts as Members of the Scheme</h2>
+		<h2 class="ui header">Add top concepts as members of the scheme</h2>
 		<p>Now that the root concepts are created, they are members of their parent container. For example, the parent container, <code>topics</code>, links to <code>design/</code> with the following membership triple:</p>
 		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#member&gt; &lt;http://localhost:8083/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
 		<p>Since the parent container is a Basic Container, the concept is also contained by it. The parent container expresses this relationship with the following containment triple:</p>
@@ -980,7 +980,7 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-section">
-			<h2 class="ui header">Add Additional Concepts</h2>
+			<h2 class="ui header">Add additional concepts</h2>
 
 		<p>Next, let's create one of the second-level concepts, Information Architecture (Concept 1.1), which is a narrower concept of the Design top concept we already created. Create and issue the following request.</p>
 
@@ -1216,7 +1216,7 @@ date: 2017-02-07 19:01:07
 </section>
 
 <section class="mainContent-section">
-	<h2 class="ui header">Secure the Application</h2>
+	<h2 class="ui header">Secure the application</h2>
 	<p>Setting up security for a Carbon application involves the following general steps:</p>
 	<ul>
 		<li>Create application roles</li>
@@ -1226,14 +1226,14 @@ date: 2017-02-07 19:01:07
 		<li>Assign permissions on your application structure to the application roles</li>
 	</ul>
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create Application Roles</h3>
+		<h3 class="ui header">Create application roles</h3>
 		<p>Roles allow us to control access to application resources. A role defines what kind of access a group of users have on one or more resources. For this app, we'll create the two roles:</p>
 		<ul>
 			<li><strong>editor</strong> - Role for all available operations.</li>
 			<li><strong>user</strong> - Role for read-only operations.</li>
 		</ul>
 		<section class="mainContent-subSection">
-			<h4>Create the Editor Role</h4>
+			<h4>Create the editor role</h4>
 			<p>Issue the following HTTP request to create the editor role.</p>
 			<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/</code></p>
 			<table class="ui celled table">
@@ -1283,7 +1283,7 @@ date: 2017-02-07 19:01:07
 		</section>
 
 		<section class="mainContent-subSection">
-			<h4>Create the User Role</h4>
+			<h4>Create the user role</h4>
 			<p>Issue the following HTTP request to create the user role.</p>
 			<p><span class="ui blue horizontal label">POST</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/</code></p>
 			<table class="ui celled table">
@@ -1335,7 +1335,7 @@ date: 2017-02-07 19:01:07
 
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create Application Users</h3>
+		<h3 class="ui header">Create application users</h3>
 		<p>For this exercise, we'll create just two users - one to add to the editor role and another to add to the user role. In Carbon, a user is also referred to as an <em>agent</em>.</p>
 		<h4>Create Agent, testuser1</h4>
 		<p>Issue the following HTTP request to create the first user (an Agent).</p>
@@ -1426,11 +1426,11 @@ date: 2017-02-07 19:01:07
 
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Assign Users to Roles</h3>
+		<h3 class="ui header">Assign users to roles</h3>
 		<p>In Carbon a role is similar to a user group. Roles are resources that can have one or more agents (users) as members.
 			In this step, we will assign testuser1 to the Editor role and testuser2 to the User role. To add an agent to a role, we
 			PUT the agent to the membership of the <code>agents</code> container that exists within the container of the role.</p>
-		<h4>Add Test User 1 to the Editor Role</h4>
+		<h4>Add test user 1 to the editor role</h4>
 		<p>Issue the following HTTP request to add testuser1 to the editor role.</p>
 		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/editor/agents/</code></p>
 		<table class="ui celled table">
@@ -1468,7 +1468,7 @@ date: 2017-02-07 19:01:07
 			}
 		</code></pre>
 		<p>A successful PUT request results in HTTP status <code>200 OK</code>.</p>
-		<h4>Add Test User 2 to the User Role</h4>
+		<h4>Add test user 2 to the user role</h4>
 		<p>Issue the following HTTP request to add testuser2 to the user role.</p>
 		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/user/agents/</code></p>
 		<table class="ui celled table">
@@ -1509,14 +1509,14 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Put the Roles into the Role-Hierarchy</h3>
+		<h3 class="ui header">Put the roles into the role-hierarchy</h3>
 
 		<p>We'll need to give permissions to our roles on resources. But we cannot assign permissions for the roles yet because the roles have not been positioned in the role
 			hierarchy. Carbon has a role hierarchy so that permissions can be inherited from the parent in any place within the hierarchy. The hierarchy always starts at
 			<code>/apps/&lt;app-name&gt;/roles/app-admin/</code>. So, in order to be able to apply permissions (ACLs - Access Control Lists) on any resource, the roles that will
 			be part of an ACL will need to exist within the role hierarchy. We can PUT both the Editor and User roles into to the role hierarchy with a single request.</p>
 
-		<h4>Put the Editor and User Roles into the Role Hierarchy</h4>
+		<h4>Put the editor and user roles into the role hierarchy</h4>
 
 		<p><span class="ui blue horizontal label">PUT</span> <code>http://localhost:8083/apps/taxonomy-hub/roles/app-admin/</code></p>
 		<table class="ui celled table">
@@ -1562,7 +1562,7 @@ date: 2017-02-07 19:01:07
 	</section>
 	<section class="mainContent-subSection">
 
-		<h3 class="ui header">Assign Permissions to the Application Roles</h3>
+		<h3 class="ui header">Assign permissions to the application roles</h3>
 
 		<p>Next, we need to assign permissions to the application roles we've created. In Carbon, resources can have an AccessControlList (ACL),
 			which defines what permissions roles have on the given resource. Let's take a look.</p>
@@ -1626,7 +1626,7 @@ date: 2017-02-07 19:01:07
 			The ACL defines an <code>accessControlEntry</code> and an <code>inheritableEntry</code>, each linking to an <code>AccessControlEntry</code> by way of a blank nodes. The entry linked by <code>accessControlEntry</code> defines access to the resource itself. The entry linked by <code>inheritableEntry</code> defines permissions that can be inherited by child resources when the child resources do not override them.
 		</p>
 
-		<h4>Give the Editor Role All Permissions and the User Role READ Permissions.</h4>
+		<h4>Give the editor role all permissions and the user role READ permissions</h4>
 		<p>The best way to modify permissions on a resource using the REST API is to start by getting the ACL for the resource as we've just done above. We can paste that ACL into a text editor, make some manual modifications, and then update it.</p>
 		<p>Doing this manually, is admittedly cumbersome, but it helps you understand how things work under the hood. For each of the roles (Editor and User), we'll need to repeat the following procedure using the ACL body copied from the step above.</p>
 

--- a/source/documentation/rest-api/getting-started/index.ejs
+++ b/source/documentation/rest-api/getting-started/index.ejs
@@ -7,27 +7,12 @@ date: 2017-02-07 19:01:07
 
 <h1>Getting Started with the REST API</h1>
 
-<div class="ui error message">
-	<div class="header">Outdated documentation</div>
-	<div class="content">
-		<p>This documentation is outdated and may not be accurate. It references actions related to a cloud service we used to provide.</p>
-		<p>We are working on updating it.</p>
-	</div>
-</div>
-
 <div class="ui message">
 	<div class="content">
-		<p>This guide describes how to build an example application using the Carbon LDP REST API. The REST API provides a way for applications to interact with the
-			Carbon platform
-			using HTTP verbs (GET, POST, PUT, DELETE, etc.) and resources identified by URIs.<br/> The REST API is considered to be a lower-level API than the JavaScript SDK.
-			Doing
-			things directly with the
-			REST API is generally more tedious than with the JavaScript SDK. However, understanding the REST API provides a lot of insight into how the platform works and can be
-			advantageous for
-			developers who seek to advance their understanding of the platform.</p>
+		<p>This guide describes how to build an example application using the Carbon LDP REST API. The REST API provides a way for applications to interact with the Carbon platform using HTTP verbs (GET, POST, PUT, DELETE, etc.) and resources identified by URIs.</p>
+		<p>The REST API is a lower-level API than the JavaScript SDK and doing things directly with the REST API is generally more tedious than with the JavaScript SDK. However, understanding the REST API provides insight into how the platform works and can be advantageous in certain scenarios.</p>
 	</div>
 </div>
-
 
 <div class="ui mobile only grid">
 	<div class="row">
@@ -35,57 +20,34 @@ date: 2017-02-07 19:01:07
 	</div>
 </div>
 
-
 <section class="mainContent-section">
-
 	<h2 class="ui header">About the example application</h2>
-
-	<p>In this guide, we'll use the REST API to create a simple, but useful taxonomy service. A taxonomy is a controlled vocabulary of terms, organized in a hierarchy, that can be
-		used for
-		classifying and organizing information. Taxonomies are commonly used in web applications. Their terms are used for tagging content and as facets to help users filter and
-		find. In this exercise,
-		you'll learn some of the the most important functions of the REST API as well as fundamental Linked Data Platform concepts. You'll also have a useful application that you
-		can use to create and
-		manage a single 'canonical' source of terms such as a corporate enterprise taxonomy. Other applications will be able to consume and use the taxonomy service using the very
-		same API.</p>
-
-	<p>In this guide, we'll use the following steps to complete the application:</p>
-
+	<p>In this guide, we'll use the REST API to create a simple, but useful taxonomy service. A taxonomy is a controlled vocabulary of terms, organized in a hierarchy, that can be used for classifying and organizing information. Taxonomies are commonly used in web applications. Their terms are used for tagging content and as facets to help users filter and find. In this guide, you'll learn some of the the most important functions of the REST API as well as fundamental Linked Data Platform concepts. You'll also have a useful application that you can use to create and manage a single 'canonical' source of terms such as a corporate enterprise taxonomy. Other applications will be able to consume and use the taxonomy service using the same API.</p>
+	<p>We'll use the following steps to complete the application:</p>
 	<ol>
-		<li>Create an account on carbonldp.com</li>
-		<li>Create an application</li>
-		<li>Model the application (vocabulary, resources, containers)</li>
-		<li>Create application resources</li>
-		<li>Secure the application</li>
+		<li>Create a User Account</li>
+		<li>Create an Application</li>
+		<li>Model the Application (Vocabulary, Resources, Containers)</li>
+		<li>Create Application Resources</li>
+		<li>Secure the Application</li>
 	</ol>
-
 	<p>Since this guide focuses on the REST API, you'll need a tool that can help you create and send HTTP requests. We recommend <a href="https://www.getpostman.com/">Postman</a>.
 		It's a great tool,
 		it's free, and it's the one we'll be featuring in this guide. But feel free to use the tool you're most comfortable with. <br> <br>
 		<img src="/assets/images/postman-logo.png" width="197" height="68">
 	</p>
-
+	<p><em><strong>Note:</strong> This guide assumes the typical host and port for a local dev environment,  <code>localhost:8080</code>. If your host and port differs, you'll need to make adjustments when using the given examples.</em></p>
 </section>
 
 
 <section class="mainContent-section">
-
-	<h2 class="ui header">Create an account on carbonldp.com</h2>
-
-	<p>To interact with Carbon through the REST API, we'll need a Carbon user account. Even this can be done through the REST API, so let's start by issuing a POST to create a new
-		account. The resource that comprises a Carbon account is known as an <em>Agent</em> - a <em>platform agent</em> to be precise. Later, you will learn about
-		<em>application agents</em>, which represent accounts specifically for users of the applications you build.
+	<h2 class="ui header">Create a User Account</h2>
+	<p>To interact with Carbon through the REST API, we'll need a user account. This can be done through the Workbench GUI, but since this is a guide on using the REST API, we'll do it by issuing a POST request through HTTP. The resource that comprises a Carbon account is known as an <em>Agent</em> - a <em>platform agent</em> to be precise. Later, you will learn about <em>application agents</em>, which represent accounts specifically for users of the applications you build.
 	</p>
-
 	<section class="mainContent-subSection">
-
-		<h3 class="ui header">Create the request</h3>
-
+		<h3 class="ui header">Create the Request</h3>
 		<p>Create the following HTTP request to create a platform account.</p>
-
-		<p><span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/platform/agents/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/platform/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -112,7 +74,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
 			@prefix vcard:&#60;http://www.w3.org/2001/vcard-rdf/3.0#&#62;.
@@ -121,43 +82,30 @@ date: 2017-02-07 19:01:07
 				a cs:Agent;
 				cs:name "Jane Doe";
 				vcard:email "jane.doe@example.org";
-				cs:password "MyStr0ngP@ssw0rd#".
+				cs:password "jane123".
 		</code></pre>
-
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Review the request</h3>
-
+		<h3 class="ui header">Review the Request</h3>
 		<p>Before issuing this request, you may want to examine its parts. To get more information about each part in the request, click to expand an item of interest below.</p>
-
 		<div class="ui styled fluid accordion">
-
 			<div class="title">
 				<i class="dropdown icon"></i> Content-Type
 			</div>
 			<div class="content">
-				<p>Since the request method is POST, the Content-Type HTTP header tells the platform what kind of content to expect in the body of the request. We use turtle (Terse
-					RDF Triple Language) in
-					our documentation because it's brief and clean. Once you understand the turtle syntax, you'll find that it's very easy to read and write. In all, Carbon
-					supports the following content types:</p>
+				<p>Since the request method is POST, the Content-Type HTTP header tells the platform what kind of content to expect in the body of the request. We use <a href="https://www.w3.org/TR/turtle/">Turtle (Terse RDF Triple Language)</a> in our documentation because it's brief and clean. Once you understand the Turtle syntax, you'll find that it's very easy to read and write. Note that Carbon also supports other content types for RDF such as:</p>
 				<ul>
 					<li>Turtle: text/turtle</li>
 					<li>JSON-LD: application/ld+json</li>
 					<li>RDF XML: application/rdf+xml</li>
 				</ul>
 			</div>
-
 			<div class="title">
 				<i class="dropdown icon"></i> Prefer
 			</div>
 			<div class="content">
-				<p>The <code>Prefer</code> header uses a link relation to specify the <em>interaction model</em> of the target resource, which is the resource we're posting to -
-					the <code>/platform/agents/</code>
-					container. By using this header, we're specifying the desired behavior of the resource. Because we're adding a member resource to the target container, we need
-					it to behave like a container
-					as opposed to an <code>RDFSource</code> or a <code>NonRDFSource</code> . In all, Carbon supports the following interaction model values for the
-					<code>Prefer</code> header:
+				<p>The <code>Prefer</code> header uses a link relation to specify the <em>interaction model</em> of the target resource, which is the resource we're posting to - the <code>/platform/agents/</code> container. By using this header, we're specifying the desired behavior of the container. Because we're adding a member resource to the container, we need it to behave like a container as opposed to an <code>RDFSource</code> or a <code>NonRDFSource</code> . Carbon supports the following interaction model values for the <code>Prefer</code> header:
 				</p>
 				<ul>
 					<li><code>http://www.w3.org/ns/ldp#Container; rel=interaction-model</code></li>
@@ -165,30 +113,21 @@ date: 2017-02-07 19:01:07
 					<li><code>http://www.w3.org/ns/ldp#NonRDFSource; rel=interaction-model</code></li>
 				</ul>
 			</div>
-
 			<div class="title">
 				<i class="dropdown icon"></i> Slug
 			</div>
 			<div class="content">
-				<p>The <code>Slug</code> header is intended to give the server a hint as to how to mint a new URI for the resource being created. If a slug is not provided, Carbon
-					will generate a random number
-					for the URI of the agent. In this case, however, we're specifying a preference to use jane-doe. Therefore, if it is available for use, the server will mint the
-					following URI:
+				<p>The <code>Slug</code> header is intended to give the server a hint about how to mint a new URI for the resource being created. If a slug is not provided, Carbon will generate a random number when minting the URI. In this case, however, we're specifying a preference to use <code>jane-doe</code>. Therefore, if it is available for use, the server will mint the following URI:
 				</p>
-
-				<p><code>{{protocolAndHost}}/platform/agents/jane-doe/</code></p>
+				<p><code>http://&lt;host&gt;/platform/agents/jane-doe/</code></p>
 			</div>
-
 			<div class="title">
 				<i class="dropdown icon"></i> Body
 			</div>
 			<div class="content">
 				<p>The body of the request is an RDF graph of triples written in Turtle, which we told the server we'd be using in the Content-Type header.</p>
-
 				<p>Using Turtle's @prefix directive we declare short prefix names so that we don't have to repeat long URIs in the triples that follow.</p>
-
 				<p>Following is a brief description of each of the required triples that come after the namespace declarations:</p>
-
 				<table class="ui celled table">
 					<thead>
 						<tr>
@@ -211,11 +150,8 @@ date: 2017-02-07 19:01:07
 						</tr>
 						<tr>
 							<td colspan="3">
-								<p>
-									The subject specifies an empty value relative to the base URI. In turtle, URIs are written enclosed in '&lt;' and '&gt;' and may be absolute RDF
-									URI References or relative to the current
-									base URI. <br/>The token 'a' in the predicate position always specifies the RDF type of the resource, which is a short way of writing:
-								</p> <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>
+								<p>The subject specifies an empty value relative to the base URI. In Turtle, URIs are written enclosed in '&lt;' and '&gt;' and may be absolute RDF URIs or relative to the current base URI.</p>
+								<p>The token 'a' in the predicate position always specifies the RDF type of the resource, which is a short way of writing: <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code></p>
 
 								<p>In the object position, we specify the RDF type as being an Agent from the Carbon LDP security vocabulary.</p>
 							</td>
@@ -256,7 +192,7 @@ date: 2017-02-07 19:01:07
 								<pre>cs:password</pre>
 							</td>
 							<td>
-								<pre>"MyStr0ngP@ssw0rd#"</pre>
+								<pre>"jane123"</pre>
 							</td>
 						</tr>
 						<tr>
@@ -269,14 +205,10 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-
-		<h3 class="ui header">Issue the request to create an account</h3>
-
+		<h3 class="ui header">Issue the Request</h3>
 		<p>Issue the POST request.</p>
-
 		<p>A successful request will result in HTTP status code 201 Created. The ETag header in the response will confirm the time of creation and the Location header will provide
 			the server minted URI for the new Agent resource. For example:</p>
-
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -291,48 +223,36 @@ date: 2017-02-07 19:01:07
 				</tr>
 				<tr>
 					<td>Location</td>
-					<td><span>{{protocolAndHost}}/platform/agents/jane-doe/</span></td>
+					<td><span>http://&lt;host&gt;/platform/agents/jane-doe/</span></td>
 				</tr>
 			</tbody>
 		</table>
-
 	</section>
 
 	<section class="mainContent-subSection">
-
-		<h3 class="ui header">Examine the new Agent resource</h3>
-
-		<p>Now, let's take a look at the newly created resource by issuing a <code>GET</code> request to the URI that was minted for the resource.
-		</p>
-
-		<p>Create the following HTTP request to get the platform Agent.</p>
-
-		<p><span class="ui blue horizontal label">GET</span> <code>{{protocolAndHost}}/platform/agents/jane-doe/</code>
-		</p>
-
+		<h3 class="ui header">Examine the New Resource</h3>
+		<p>You can now examine the newly created resource by issuing a <code>GET</code> request to the URI that was minted for it.</p>
+		<p>Create the following HTTP request to get the Platform Agent.</p>
+		<p><span class="ui blue horizontal label">GET</span> <code>http://&lt;host&gt;/platform/agents/jane-doe/</code></p>
 		<p>Note the trailing slash in the URI. An RDFSource created in Carbon is automatically also a Container (a feature Carbon manages for you), so the
 			server-minted URI always ends with a trailing slash.</p>
-
 		<p>You will need to authorize the request using the username and password of the agent that was defined in the body of the former POST request. Both the username and
 			password are case-sensitive; use the same case you used when defining the username and password in the Agent resource.</p>
-
 		<table class="ui celled table">
 			<tbody>
 				<tr>
 					<td><strong>Username</strong></td>
-					<td>jane.doe5@example.org</td>
+					<td>jane.doe@example.org</td>
 				</tr>
 				<tr>
 					<td><strong>Password</strong></td>
-					<td>MyStr0ngP@ssw0rd#</td>
+					<td>jane123</td>
 				</tr>
 			</tbody>
 		</table>
-
 		<p>If you paste the URI in the address bar of your web browser and hit enter, for example, you should be prompted for the username and password. If you issue the request
 			with Postman or another tool, you should add Basic Auth to the request.<br/> <br/>Let's also add an Accept header to change the format of the response to JSON LD.
 		</p>
-
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -342,7 +262,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</thead>
 			<tbody>
-
 				<tr>
 					<td>Authorization</td>
 					<td>Basic ...</td>
@@ -355,17 +274,13 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>200 OK</strong>
-		</p>
-
+		<p><strong>200 OK</strong></p>
 		<pre><code class="json">
 			[
 			   &#123;
 			      "@graph":[
 			         &#123;
-			            "@id":"{{protocolAndHost}}/platform/agents/jane-doe/",
+			            "@id":"http://&lt;host&gt;/platform/agents/jane-doe/",
 			            "@type":[
 			               "http://www.w3.org/ns/ldp#BasicContainer",
 			               "http://www.w3.org/ns/ldp#RDFSource",
@@ -417,7 +332,7 @@ date: 2017-02-07 19:01:07
 			            ],
 			            "https://carbonldp.com/ns/v1/security#platformRole":[
 			               &#123;
-			                  "@id":"{{protocolAndHost}}/platform/roles/app-developer/"
+			                  "@id":"http://&lt;host&gt;/platform/roles/app-developer/"
 			               &#125;
 			            ],
 			            "https://carbonldp.com/ns/v1/security#salt":[
@@ -427,26 +342,19 @@ date: 2017-02-07 19:01:07
 			            ]
 			         &#125;
 			      ],
-			      "@id":"{{protocolAndHost}}/platform/agents/jane-doe/"
+			      "@id":"http://&lt;host&gt;/platform/agents/jane-doe/"
 			   &#125;
 			]
 		</code></pre>
 	</section>
 </section>
-
 <section class="mainContent-section">
-	<h2 class="ui header">Create an application</h2>
-
+	<h2 class="ui header">Create an Application</h2>
 	<p>With your newly created platform account, you can now create an Application.</p>
-
 	<p>To create an application, issue the following request. Be sure to use your own unique name for the Slug or omit the Slug. You should also provide a unique name for the
 		application in the
 		body of the request.</p>
-
-	<p>
-		<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/platform/apps/</code>
-	</p>
-
+	<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/platform/apps/</code></p>
 	<table class="ui celled table">
 		<thead>
 			<tr>
@@ -478,11 +386,7 @@ date: 2017-02-07 19:01:07
 			</tr>
 		</tbody>
 	</table>
-
-	<p>
-		<strong>Body (required)</strong>
-	</p>
-
+	<p><strong>Body (required)</strong></p>
 	<pre><code class="turtle">
 		@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
 
@@ -490,41 +394,18 @@ date: 2017-02-07 19:01:07
 			a cs:Application;
 			cs:name "Taxonomy Hub".
 	</code></pre>
-
 	<p>Issue the POST request.</p>
-
-	<p>A successful request will result in HTTP status code 201 Created. It will also respond with the server-minted URI for the Application resource, which in the case of our
-		example is:</p>
-
-	<p>
-		<code>{{protocolAndHost}}/platform/apps/taxonomy-hub/</code>
-	</p>
-
+	<p>A successful request will result in HTTP status code 201 Created. It will also respond with the server-minted URI for the Application resource, which in the case of our example is:</p>
+	<p><code>http://&lt;host&gt;/platform/apps/taxonomy-hub/</code></p>
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Examine the application root container</h3>
-
-		<p>You can always verify a newly created resource by issuing a GET request to its URI, but it's important to keep in mind that the URI created for the Application only
-			references the
-			metadata resource for your application. When a new Application is created, Carbon also creates an access point at the following URI:</p>
-
-		<p>
-			<code>{{protocolAndHost}}/apps/&lt;app-slug&gt;/</code>
-		</p>
-
+		<h3 class="ui header">Examine the Application Root Container</h3>
+		<p>You can always verify a newly created resource by issuing a GET request to its URI, but it's important to keep in mind that the URI created for the Application only references the metadata resource for your application. When a new Application is created, Carbon also creates an access point at the following URI:</p>
+		<p><code>http://&lt;host&gt;/apps/&lt;app-slug&gt;/</code></p>
 		<p>So, in the case of our example, the application's access point or root URI would be:</p>
-
-		<p>
-			<code>{{protocolAndHost}}/apps/taxonomy-hub/</code>
-		</p>
-
+		<p><code>http://&lt;host&gt;/apps/taxonomy-hub/</code></p>
 		<p>The difference between this URI and the URI of the Application metadata resource is the absence of the /platform segment after the host name.</p>
-
 		<p>Issue the following request to examine the root container that Carbon created for you.</p>
-
-		<p>
-			<span class="ui blue horizontal label">GET</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">GET</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -546,12 +427,8 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>Notice that this time, since we did not specify an Accept header of type <code>application/ld+json</code>, the response we'll get back will be in the default
-			Turtle syntax. While JSON-LD is often easiest to process with JavaScript, you will typically find Turtle to be a little more compact and easier to read.</p>
-
+		<p>Notice that this time, since we did not specify an Accept header of type <code>application/ld+json</code>, the response we'll get back will be in the default Turtle syntax. While JSON-LD is often easiest to process with JavaScript, you will typically find Turtle to be a little more compact and easier to read.</p>
 		<p><strong>Example root container for an app</strong></p>
-
 		<pre><code class="turtle">
 			&#60;https://local.carbonldp.com/apps/taxonomy-hub/&#62;
 				a
@@ -569,17 +446,11 @@ date: 2017-02-07 19:01:07
 				&#60;https://carbonldp.com/ns/v1/platform#modified&#62; "2016-04-01T11:58:03.543-05:00"^^&#60;http://www.w3.org/2001/XMLSchema#dateTime&#62; .
 		</code></pre>
 	</section>
-
 </section>
 
 <section class="mainContent-section">
-
-	<h2 class="ui header">Model the application</h2>
-
-	<p>Now that you have an application root created, you can begin to create RDF documents in the application. Before you start posting arbitrary RDF documents, however, it's a
-		good idea to
-		design a general model for the application. Answering the following questions can help you determine what the model should be.</p>
-
+	<h2 class="ui header">Model the Application (Vocabulary, Resources, Containers)</h2>
+	<p>Now that you have an application root created, you can begin to create RDF documents in the application. Before you start posting arbitrary RDF documents, however, it's a good idea to design a general model for the application. Answering the following questions can help you determine what the model should be.</p>
 	<ul>
 		<li>What entities will the resources in our application represent?</li>
 		<li>What data attributes (or triples) will they have?</li>
@@ -587,76 +458,38 @@ date: 2017-02-07 19:01:07
 		<li>What kinds of relationships (links) will we make in our data or with data in other sources?</li>
 		<li>How will we use container behavior to create, modify, and enumerate member documents?</li>
 	</ul>
-
-	<p>Answering these questions up-front will help provide a logical and structured way to build your application. One way to think about this is to think about the most common
-		use cases for the
-		data and the following six areas of consideration:</p>
-
+	<p>Answering these questions up-front will help provide a logical and structured way to build your application. One way to think about this is to think about the most common use cases for the data and the following six areas of consideration:</p>
 	<ol>
-		<li><strong>Classes/Entities</strong> - The taxonomy terms are the main item of interest or <em>entity</em> we'll be working with - the main resource we'll be managing in
-			the Carbon app.
-		</li>
+		<li><strong>Classes/Entities</strong> - The taxonomy terms are the main item of interest or <em>entity</em> we'll be working with - the main resource we'll be managing in the Carbon app.</li>
 		<li><strong>Class/Entity Properties</strong> - Taxonomy terms are pretty simple; they're just concepts or labels. Perhaps they can be expressed in multiple languages.</li>
 		<li><strong> <strong>Class/Entity</strong> Relationships
-			</strong> - A taxonomy implies that these terms are organized in a hierarchy, so we need to think about how to use container behavior to support that structure.
-		</li>
-		<li><strong>Application Functionality</strong> - The data for our application, the taxonomy terms, will typically be metadata used to help describe the subject and nature
-			of information in
-			other systems, so we'll allow other apps to make REST requests to consume the service.
-		</li>
-		<li><strong>Security</strong> - We'll need varying degrees of access to the data in our app, so we'll need to come up with the appropriate roles for controlling access.
-		</li>
-		<li><strong>User Interface</strong> - It's also likely that we'll want a user interface that makes it easy for permitted individuals to visualize and manage the taxonomy.
-			Such a UI will likely employ the use of a tree control.
-		</li>
+			</strong> - A taxonomy implies that these terms are organized in a hierarchy, so we need to think about how to use container behavior to support that structure.</li>
+		<li><strong>Application Functionality</strong> - The data for our application, the taxonomy terms, will typically be metadata used to help describe the subject and nature of information in other systems, so we'll allow other apps to make REST requests to consume the service.</li>
+		<li><strong>Security</strong> - We'll need varying degrees of access to the data in our app, so we'll need to come up with the appropriate roles for controlling access.</li>
+		<li><strong>User Interface</strong> - It's also likely that we'll want a user interface that makes it easy for permitted individuals to visualize and manage the taxonomy. Such a UI will likely employ the use of a tree control.</li>
 	</ol>
 
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Re-using an established linked data vocabulary called SKOS</h3>
-
-		<p>It's always a best-practice to re-use established linked data vocabularies instead of (re-)inventing duplicates and as it turns out, there's already a good vocabulary
-			that fits the needs of our application. It's called SKOS (Simple Knowledge Organization System). According to the SKOS Primer, it &quot;provides a model for
-			expressing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, folksonomies, and other
-			similar types of controlled vocabulary.&quot; Sounds right up our alley, doesn't it? When we investigate SKOS, we not only see that it will suit the needs of our
-			app, but that it provides a lot of clues about how we should model everything.</p>
+		<h3 class="ui header">Re-Using an Established Linked Data Vocabulary Called SKOS</h3>
+		<p>It's always a best-practice to re-use established linked data vocabularies instead of inventing duplicates and, as it turns out, there's already a good vocabulary that fits the needs of our application. It's called <a href="https://www.w3.org/TR/skos-reference/">SKOS (Simple Knowledge Organization System)</a>. According to the <a href="https://www.w3.org/TR/skos-primer/">SKOS Primer</a>, it &quot;provides a model for expressing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, folksonomies, and other similar types of controlled vocabulary.&quot; Sounds right up our alley, doesn't it? When we investigate SKOS, we not only see that it will suit the needs of our app, but that it provides a lot of clues about how we should model everything.</p>
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Mini SKOS Simple Knowledge Organization System primer</h3>
-
-		<p>
-			<strong>skos:Concept</strong>
-		</p>
-
-		<p>
-			SKOS introduces the class <code>skos:Concept</code> , which allows implementors to assert that a given resource is a concept. This is done in two steps:
-		</p>
-
+		<h3 class="ui header">Mini SKOS Primer</h3>
+		<p><strong>skos:Concept</strong></p>
+		<p>SKOS introduces the class <code>skos:Concept</code> , which allows implementors to assert that a given resource is a concept. This is done in two steps:</p>
 		<ol>
 			<li>by creating (or reusing) a Uniform Resource Identifier (URI) to uniquely identify the concept.</li>
 			<li>by asserting in RDF, using the property <code>rdf:type</code>, that the resource identified by this URI is of type <code>skos:Concept</code>.
 			</li>
 		</ol>
+		<p>So, there you can see, we already have the class that can represent a taxonomy term. This means that when we create resources that represent taxonomy terms, we simply need to assert that it's an rdf:type skos:Concept. For example:</p>
+		<p><code>&lt;Carbon-document-URI&gt; a skos:Concept.</code></p>
+		<p>(Remember, ' <code>a</code> ' in turtle is shorthand for <code>rdf:type</code> ).</p>
+		<p><strong>skos:prefLabel</strong></p>
+		<p>A SKOS Concept can have a preferred lexical label, which will be useful in representing it in a user interface. We'll be able to define a label for a concept as shown below.</p>
 
-		<p>So, there you can see, we already have the class that can represent a taxonomy term. This means that when we create resources that represent taxonomy terms, we simply
-			need to assert that
-			it's an rdf:type skos:Concept. For example:</p>
-
-		<p>
-			<code>&lt;Carbon-document-URI&gt; a skos:Concept.</code>
-		</p>
-
-		<p>
-			(Remember, ' <code>a</code> ' in turtle is shorthand for <code>rdf:type</code> ).
-		</p>
-
-		<p>
-			<strong>skos:prefLabel</strong>
-		</p>
-
-		<p>A SKOS Concept can have a preferred lexical label, which will be useful in representing it in a user interface. We'll be able to define a label for a concept as shown
-			below.</p>
 		<pre><code class="turtle">
 			&#60;carbon-document-uri&#62;
 				a skos:Concept;
@@ -672,19 +505,14 @@ date: 2017-02-07 19:01:07
 				skos:prefLabel "animaux"@fr.
 		</code></pre>
 
-		<p>There is also a <code>skos:altLabel</code> and a <code>skos:hiddenLabel</code>, which can be used in the future, but we'll keep it simple for now and just stick to the
-			<code>skos:prefLabel</code>.</p>
+		<p>There is also a <code>skos:altLabel</code> and a <code>skos:hiddenLabel</code>, which can be used in the future, but we'll keep it simple for now and just stick to the <code>skos:prefLabel</code>.</p>
 
-		<p>
-			<strong>skos:broader and skos:narrower (semantic relationships)</strong>
-		</p>
+		<p><strong>skos:broader and skos:narrower (semantic relationships)</strong></p>
 
 		<p>The <code>skos:broader</code> and <code>skos:narrower</code> properties give us what we need to express hierarchical links between our concepts.</p>
 
 		<p>
-			To assert that one concept is broader in meaning (i.e. more general) than another, the <code>skos:broader</code> property is used. The <code>skos:narrower</code>
-			property is used to assert the inverse, namely when one concept is narrower in meaning (i.e. more specific) than another. For example:
-		</p>
+			To assert that one concept is broader in meaning (i.e. more general) than another, the <code>skos:broader</code> property is used. The <code>skos:narrower</code> property is used to assert the inverse, namely when one concept is narrower in meaning (i.e. more specific) than another. For example:</p>
 
 		<pre><code class="turtle">
 			&#60;carbon-document-uri&#62;
@@ -693,51 +521,20 @@ date: 2017-02-07 19:01:07
 				skos:narrower ex:mammals.
 		</code></pre>
 
-		<p>
-			In SKOS, there is also the notion of a <code>skos:related</code> link, which is used to assert an associative relationship. But again, we can add such things in the
-			future. For now, we'll just stick to the parent/child relationship afforded by <code>skos:broader</code> and <code>skos:narrower</code> .
+		<p>In SKOS, there is also the notion of a <code>skos:related</code> link, which is used to assert an associative relationship. But again, we can add such things in the future. For now, we'll just stick to the parent/child relationship afforded by <code>skos:broader</code> and <code>skos:narrower</code> .
 		</p>
 
-		<p>
-			<strong>skos:inScheme</strong>
-		</p>
+		<p><strong>skos:inScheme</strong></p>
 
-		<p>
-			The <code>skos:inScheme</code> property is another we'll use in concept documents. This property will allow us to associate a concept to one or more taxonomies. In our
-			app, taxonomies can be represented by the <code>skos:ConceptScheme</code> , which is described next.
+		<p>The <code>skos:inScheme</code> property is another we'll use in concept documents. This property will allow us to associate a concept to one or more taxonomies. In our app, taxonomies can be represented by the <code>skos:ConceptScheme</code> , which is described next.
 		</p>
-
-		<p>
-			<strong>skos:ConceptScheme</strong>
-		</p>
-
-		<p>
-			The <code>skos:ConceptScheme</code> class will represent a taxonomy that concepts belong to. We'll use two properties with this class: <code>dct:title</code> and <code>skos:hasTopConcept</code>
-			.
-		</p>
-
-		<p>
-			<strong>dct:title</strong>
-		</p>
-
-		<p>
-			The <code>dct:title</code> property is actually from another popular vocabulary - the Terms vocabulary of the Dublin Core Metadata Initiative. We'll use it to add a
-			title to the taxonomies we
-			create.
-		</p>
-
-		<p>
-			<strong>skos:hasTopConcept</strong>
-		</p>
-
-		<p>
-			The <code>skos:hasTopConcept</code> property will provide an efficient access to the entry points of our broader/narrower concept hierarchies. This property will allow
-			our app to link a
-			concept scheme (a taxonomy in our case) to the concepts it contains. The top concepts will represent the root concepts in the taxonomies we create.
-		</p>
-
+		<p><strong>skos:ConceptScheme</strong></p>
+		<p>The <code>skos:ConceptScheme</code> class will represent a taxonomy that concepts belong to. We'll use two properties with this class: <code>dct:title</code> and <code>skos:hasTopConcept</code>.</p>
+		<p><strong>dct:title</strong></p>
+		<p>The <code>dct:title</code> property is actually from another popular vocabulary - the Terms vocabulary of the Dublin Core Metadata Initiative. We'll use it to add a title to the taxonomies we create.</p>
+		<p><strong>skos:hasTopConcept</strong></p>
+		<p>The <code>skos:hasTopConcept</code> property will provide an efficient access to the entry points of our broader/narrower concept hierarchies. This property will allow our app to link a concept scheme (a taxonomy in our case) to the concepts it contains. The top concepts will represent the root concepts in the taxonomies we create.</p>
 		<p>Here's an example of what an instance of a ConceptScheme with four top concepts might look like:</p>
-
 		<pre><code class="turtle">
 			&#60;carbon-document-uri&#62;
 				rdf:type skos:ConceptScheme;
@@ -748,22 +545,13 @@ date: 2017-02-07 19:01:07
 					&#60;carbon-document-uri&#62;,
 					&#60;carbon-document-uri&#62;.
 		</code></pre>
-
-		<p>We now have all that we need to for the classes and properties required for our app. Relationships (links) between some of these properties as well as between additional
-			LDP properties
-			will allow us to organize concepts in a hierarchy and within a taxonomy concept scheme.</p>
-
+		<p>We now have all that we need to for the classes and properties required for our app. Relationships (links) between some of these properties as well as between additional LDP properties will allow us to organize concepts in a hierarchy and within a taxonomy concept scheme.</p>
 		<p>Before we move on, it's worth mentioning that prefixes we've used come from the following namespaces.</p>
-
-		<p>
-			<b>Namespaces used</b>
-		</p>
-
+		<p><b>Namespaces used</b></p>
 		<pre><code class="turtle">
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
 			@prefix dct:&#60;http://purl.org/dc/terms/&#62;.
 		</code></pre>
-
 		<p>There's more to SKOS than what we've covered here, so if you're interested in learning more, the following are good reference resources:</p>
 		<ul>
 			<li><a href="http://www.w3.org/2004/02/skos/intro">Introduction to SKOS</a></li>
@@ -773,15 +561,12 @@ date: 2017-02-07 19:01:07
 	</section>
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Consider the role of LDP containers</h3>
-
+		<h3 class="ui header">Consider the Role of LDP Containers</h3>
 		<p>It may seem intuitive to model the container behavior for our application in such way that each concept is a container to its narrower concepts. Or, in other words, so
 			that
 			narrower concepts
 			are represented as membership triples on their broader concepts.</p>
-
 		<p>Let's imagine the following simple taxonomy, for example:</p>
-
 		<ul>
 			<li>Topics (ConceptScheme)
 				<ul>
@@ -818,23 +603,13 @@ date: 2017-02-07 19:01:07
 			</li>
 		</ul>
 		<p>Though Carbon enforces no restriction on doing this, there are a few reasons why we might not want to.</p>
-
 		<p>First, as the depth of your taxonomy increases, so too does the length of your concept URIs. We should keep in mind that the fully qualified URI for each concept will
 			also include the
 			host and the base URI to the app. In this model, just one level deeper from the top concept could produce the following URI:</p>
-
-		<p>
-			<code>{{protocolAndHost}}/platform/apps/taxonomy-hub/topics/technology/javascript</code>
-		</p>
-
+		<p><code>http://&lt;host&gt;/platform/apps/taxonomy-hub/topics/technology/javascript</code></p>
 		<p>You can see how the addition of just a few more levels could lengthen the URI significantly.</p>
-
-		<p>Another possible problem is that it creates a tight coupling between the URI for each concept and the location of the concept in a hierarchy. When you move categories
-			around, you'd have to revise the URIs for several other concepts to keep the implication in tact. Furthermore, if you ever wanted to share concepts between branches
-			of a taxonomy, or across multiple taxonomies, the implication of the URI would only be logical in one of the cases.</p>
-
+		<p>Another possible problem is that it creates a tight coupling between the URI for each concept and the location of the concept in a hierarchy. When you move categories around, you'd have to revise the URIs for several other concepts to keep the implication in tact. Furthermore, if you ever wanted to share concepts between branches of a taxonomy, or across multiple taxonomies, the implication of the URI would only be logical in one of the cases.</p>
 		<p>Finally, there is a more elegant approach for leveraging container behavior that can reduce the work required to manage the taxonomies.</p>
-
 		<ul>
 			<li>taxonomy-hub/schemes/
 				<ul>
@@ -851,34 +626,18 @@ date: 2017-02-07 19:01:07
 				</ul>
 			</li>
 		</ul>
-		<p>
-			We've flattened things out a bit so that all concepts are direct children of the <code>topics/</code> container. We've also added a new container called
-			<code>top-concepts/</code> to help us manage which concepts are root (top) concepts in the scheme.
-		</p>
-
+		<p>We've flattened things out a bit so that all concepts are direct children of the <code>topics/</code> container. We've also added a new container called <code>top-concepts/</code> to help us manage which concepts are root (top) concepts in the scheme.</p>
 		<p>As we work with this alternative approach, you'll begin to see why it's an improvement.</p>
 	</section>
-
 </section>
 
 <section class="mainContent-section">
-
-	<h2 class="ui header">Create application resources</h2>
-
+	<h2 class="ui header">Create Application Resources</h2>
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create the schemes/ container</h3>
-
-		<p>
-			Let's start by creating the <code>schemes/</code> container. Since the application will always have only one <code>schemes/</code> container, this will be a one-time
-			affair.
-		</p>
-
+		<h3 class="ui header">Create the schemes/ Container</h3>
+		<p>Let's start by creating the <code>schemes/</code> container. Since the application will always have only one <code>schemes/</code> container, this will be a one-time affair.</p>
 		<p>Create the following request.</p>
-
-		<p>
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -910,11 +669,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 
@@ -922,27 +677,15 @@ date: 2017-02-07 19:01:07
 				a ldp:BasicContainer.
 		</code></pre>
 
-		<p>We're specifying a Basic Container so that membership will automatically be recorded on the container when new schemes are posted, which will provide an easy way to list
-			available schemes.</p>
-
+		<p>We're specifying a Basic Container so that membership will automatically be recorded on the container when new schemes are posted, which will provide an easy way to list available schemes.</p>
 		<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>
 
 	</section>
 
 	<section class="mainContent-subSection">
-
-		<h3 class="ui header">Create example Concept Scheme</h3>
-
-		<p>
-			Now that we have the <code>schemes/</code> container, we can create one or more Concept Scheme containers within it. Since this is an action that would likely be
-			repeated by end-users, it would make sense to incorporate the capability into a user interface. For now, however, let's be clear on what is required for the
-			underlying HTTP request.
-		</p>
-
-		<p>
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/</code>
-		</p>
-
+		<h3 class="ui header">Create Example Concept Scheme</h3>
+		<p>Now that we have the <code>schemes/</code> container, we can create one or more Concept Scheme containers within it. Since this is an action that would likely be repeated by end-users, it would make sense to incorporate the capability into a user interface. For now, however, let's be clear on what is required for the underlying HTTP request.</p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -975,11 +718,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
@@ -990,43 +729,21 @@ date: 2017-02-07 19:01:07
 				ldp:memberOfRelation skos:inScheme;
 				dct:title "Topics".
 		</code></pre>
-
 		<p>Take note of the following triple on the container:</p>
-
-		<p>
-			<code>&lt;&gt; ldp:memberOfRelation skos:inScheme</code>
-		</p>
-
+		<p><code>&lt;&gt; ldp:memberOfRelation skos:inScheme</code></p>
 		<p>This configures the container to automatically add a link in each member that is added to the container. Whenever we POST a new concept into this scheme, Carbon will
 			automatically add the following triple to the concept document:</p>
-
-		<p>
-			<code>&lt;concept-uri&gt; skos:inScheme &lt;{{protocolAndHost}}/apps/taxonomy-hub/schemes/&gt;</code>
-		</p>
-
+		<p><code>&lt;concept-uri&gt; skos:inScheme &lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/&gt;</code></p>
 		<p>Create and issue the request. A successful request should result in HTT status 201 Created.</p>
-
 		<p>This illustrates an interesting use of BasicContainer behavior. In the next step, we'll see another interesting use of container behavior with a DirectContainer.</p>
 	</section>
 
 	<section class="mainContent-subSection">
-
 		<h3 class="ui header">Create the top-concepts/ Direct Container</h3>
-
-		<p>
-			As stated earlier, the <code>top-concepts/</code> container will give us an easy way to list the root concepts in a taxonomy. Our application should therefore create a
-			<code>top-concepts/</code> container in every scheme created. You'd likely want to automate the creation of this container in the function that creates the scheme
-			container, but for now, we'll do it by hand to complete the exercise. That is to say, for now, we're only supporting one concept scheme (taxonomy).
-		</p>
-
+		<p>As stated earlier, the <code>top-concepts/</code> container will give us an easy way to list the root concepts in a taxonomy. Our application should therefore create a <code>top-concepts/</code> container in every scheme created. You'd likely want to automate the creation of this container in the function that creates the scheme container, but for now, we'll do it by hand to complete the exercise. That is to say, for now, we're only supporting one concept scheme (taxonomy).</p>
 		<p>This time, we'll make use of a Direct Container. A Direct Container creates an access point that helps you manage membership triples in another container.</p>
-
 		<p>Create the following request.</p>
-
-		<p>
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1058,77 +775,29 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
 
 			&#60;&#62;
 				a ldp:DirectContainer;
-				ldp:membershipResource &#60;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/&#62;;
+				ldp:membershipResource &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/&#62;;
 				ldp:hasMemberRelation skos:hasTopConcept.
 		</code></pre>
-
-		<p>
-			Notice, this time, we use the Prefer header to set the interaction model to RDF Source instead of Container. This keeps the <code>topics/</code> container that we're
-			posting to from recognizing
-			the <code>top-concepts/</code> container as a member. That is to say, it keeps it from recording a membership triple for the <code>top-concepts/</code> container. The
-			outcome we want is for all
-			concepts to be listed as members of the <code>topics/</code> container, but not the <code>top-concepts/</code> container.
-		</p>
-
-		<p>
-			The <code>ldp:membershipResource</code> predicate of this Direct Container specifies an entirely different resource where membership triples should be written.
-			Whenever we post to this
-			container (the <code>top-concepts/</code> container), a membership triple will be written to the specified resource, which is the <code>topics/</code> container. In
-			other words, if we later put
-			a Concept to the <code>top-concepts/</code> container, that concept will become a member of the <code>topics/</code> container. Why would we want to do this? To
-			understand, we have to consider
-			the <code>ldp:hasMemberRelation</code> predicate, which is also used.
-		</p>
-
-		<p>
-			Whenever the <code>top-concepts/</code> container writes a membership triple to the container specified by <code>ldp:membershipResource</code> , it will use the
-			predicate <code>skos:hasTopConcept</code>
-			to represent that membership relationship because of what's defined by <code>ldp:hasMemberRelation</code> . This feature exists so that we can use a different
-			vocabulary other than the standard
-			LDP vocabulary to represent membership relations. When we post to <code>top-concepts/</code> , for example, the following statement will be added to the
-			<code>topics/</code> container:
-		</p>
-
-		<p>
-			<code>&lt;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/&gt; skos:hasTopConcept &lt;member-URI&gt;</code>
-		</p>
-
-		<p>
-			We will not be posting to the <code>top-concepts/</code> container to create new documents. Instead, we'll post new concepts to the <code>topics/</code> container to
-			create them and then later
-			put the top concepts into the <code>top-concepts/</code> container. If you <em>post</em> a new resource to a container, the container creates a membership triple and a
-			containment triple, but
-			if you <em>put</em> an existing resource to a container, the container creates only a membership triple.
-		</p>
-
+		<p>Notice, this time, we use the Prefer header to set the interaction model to RDF Source instead of Container. This keeps the <code>topics/</code> container that we're posting to from recognizing the <code>top-concepts/</code> container as a member. That is to say, it keeps it from recording a membership triple for the <code>top-concepts/</code> container. The outcome we want is for all concepts to be listed as members of the <code>topics/</code> container, but not the <code>top-concepts/</code> container.</p>
+		<p>The <code>ldp:membershipResource</code> predicate of this Direct Container specifies an entirely different resource where membership triples should be written. Whenever we post to this container (the <code>top-concepts/</code> container), a membership triple will be written to the specified resource, which is the <code>topics/</code> container. In other words, if we later put a Concept to the <code>top-concepts/</code> container, that concept will become a member of the <code>topics/</code> container. Why would we want to do this? To understand, we have to consider the <code>ldp:hasMemberRelation</code> predicate, which is also used.</p>
+		<p>Whenever the <code>top-concepts/</code> container writes a membership triple to the container specified by <code>ldp:membershipResource</code> , it will use the predicate <code>skos:hasTopConcept</code> to represent that membership relationship because of what's defined by <code>ldp:hasMemberRelation</code> . This feature exists so that we can use a different vocabulary other than the standard LDP vocabulary to represent membership relations. When we post to <code>top-concepts/</code> , for example, the following statement will be added to the <code>topics/</code> container:</p>
+		<p><code>&lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/&gt; skos:hasTopConcept &lt;member-URI&gt;</code></p>
+		<p>We will not be posting to the <code>top-concepts/</code> container to create new documents. Instead, we'll post new concepts to the <code>topics/</code> container to create them and then later put the top concepts into the <code>top-concepts/</code> container. If you <em>post</em> a new resource to a container, the container creates a membership triple and a containment triple, but if you <em>put</em> an existing resource to a container, the container creates only a membership triple.</p>
 		<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>
 	</section>
 
 	<section class="mainContent-section">
-		<h2 class="ui header">Create a root Concept</h2>
-
-		<p>Now, we're ready to start creating concepts in our Topics taxonomy. This, of course, is a function that the GUI of our app would probably handle, but doing a few
-			manually is important to
-			this learning exercise.</p>
-
+		<h2 class="ui header">Create a Root Concept</h2>
+		<p>Now, we're ready to start creating concepts in our Topics taxonomy. This, of course, is a function that the GUI of our app would probably handle, but doing a few manually is important to this learning exercise.</p>
 		<p>For our first Concept, create the following request.</p>
-
-		<p>
-
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1160,11 +829,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
@@ -1176,63 +841,24 @@ date: 2017-02-07 19:01:07
 				skos:prefLabel "Design"@en;
 				skos:prefLabel "DiseÃ±o"@es.
 		</code></pre>
-
-		<p>
-			Notice, this time that the ldp:hasMemberRelation is skos:narrower. That means that any concept that is later PUT to this container will force a membership triple to be
-			written on the container
-			using <code>skos:narrower</code> as the predicate.
-		</p>
-
-		<p>
-			The <code>ldp:memberOfRelation</code> allows the inverse to be true. Any concept that is added to the membership of this container will get a triple written to it,
-			which defines this concept as
-			its <code>skos:broader</code> concept. When we add the Information Architecture concept as a member, for example, the <code>information-architecture/</code> resource
-			will receive the following
-			triple.
-		</p>
-
-		<p>
-			<code>&lt;...topics/design/information-architecture/&gt; skos:broader &lt;......topics/design/&gt;</code>
-		</p>
-
-		<p>As we can see now, features of a container support what's needed to use the SKOS vocabulary. From any concept, we have a way to look both downwards and upwards in the
-			hierarchy.</p>
-
+		<p>Notice, this time that the ldp:hasMemberRelation is skos:narrower. That means that any concept that is later PUT to this container will force a membership triple to be written on the container using <code>skos:narrower</code> as the predicate.</p>
+		<p>The <code>ldp:memberOfRelation</code> allows the inverse to be true. Any concept that is added to the membership of this container will get a triple written to it,
+			which defines this concept as its <code>skos:broader</code> concept. When we add the Information Architecture concept as a member, for example, the <code>information-architecture/</code> resource
+			will receive the following triple.</p>
+		<p><code>&lt;...topics/design/information-architecture/&gt; skos:broader &lt;......topics/design/&gt;</code></p>
+		<p>As we can see now, features of a container support what's needed to use the SKOS vocabulary. From any concept, we have a way to look both downwards and upwards in the hierarchy.</p>
 		<p>Issue the request. A successful response should provide the HTTP status code 201 Created.</p>
 	</section>
 
 	<section class="mainContent-section">
-
-		<h2 class="ui header">Add root Concepts as member of the scheme</h2>
-
-		<p>
-			Now that the root concept is created, it is a member of its parent container. In other words, its parent container, <em>topics</em>, links to it with the following
-			membership triple:
-		</p>
-
-		<p>
-			<code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#member&gt; &lt;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/design/&gt;</code>
-		</p>
-
-		<p>Since the parent container is a Basic Container, the concept is also contained by it. The parent container expresses this relationship with the following containment
-			triple:</p>
-
-		<p>
-			<code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#contains&gt; &lt;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/design/&gt;</code>
-		</p>
-
-		<p>What's needed now is to identify the root concept as a member of the topics scheme with the skos:hasTopConcept relation. This will be done when we PUT the concept to the
-			top-concepts
-			container.</p>
-
-		<p>
-			<span>Create the following request.</span>
-		</p>
-
-		<p>
-			<span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/top-concepts/</code>
-		</p>
-
+		<h2 class="ui header">Add Root Concepts as Member of the Scheme</h2>
+		<p>Now that the root concept is created, it is a member of its parent container. In other words, its parent container, <em>topics</em>, links to it with the following membership triple:</p>
+		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#member&gt; &lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
+		<p>Since the parent container is a Basic Container, the concept is also contained by it. The parent container expresses this relationship with the following containment triple:</p>
+		<p><code>&lt;&gt; &lt;http://www.w3.org/ns/ldp#contains&gt; &lt;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/&gt;</code></p>
+		<p>What's needed now is to identify the root concept as a member of the topics scheme with the skos:hasTopConcept relation. This will be done when we PUT the concept to the top-concepts container.</p>
+		<p><span>Create the following request.</span></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/top-concepts/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1259,36 +885,19 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
 			_:b0
 				a c:AddMemberAction;
-				c:targetMember &#60;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/design/&#62;.
+				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/&#62;.
 		</code></pre>
-
-		<p>Notice that the Carbon vocabulary is used. The class of the resource is a Carbon <code>AddMemberAction</code> with the specified member to add to the container we're
-			putting it to.</p>
-
+		<p>Notice that the Carbon vocabulary is used. The class of the resource is a Carbon <code>AddMemberAction</code> with the specified member to add to the container we're putting it to.</p>
 		<p>Issue the request. A successful response should provide 200 OK.</p>
-
-		<p>
-			Now, if you examine the <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code> container (GET), you'll see the membership triple link to the
-			<code>design/</code> concept written
-			as <code>skos:hasTopConcept</code>.
-		</p>
-
+		<p>Now, if you examine the <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code> container (GET), you'll see the membership triple link to the <code>design/</code> concept written as <code>skos:hasTopConcept</code>.</p>
 		<p>In the same way, let's add the other top concept, Technology. Create and issue the following request, which should result in the 201 Created status code.</p>
-
-		<p>
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1320,11 +929,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
@@ -1336,16 +941,9 @@ date: 2017-02-07 19:01:07
 			    skos:prefLabel "Technology"@en;
 			    skos:prefLabel "Tecnología"@es.
 		</code></pre>
-
 		<p>A successful POST should result in HTTP status 201 Created.</p>
-
-		<p>Again, identify this root concept as a member of the topics scheme with the skos:hasTopConcept relation, which is done when we PUT the concept to the top-concepts
-			container.</p>
-
-		<p>
-			<span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/top-concepts/</code>
-		</p>
-
+		<p>Again, identify this root concept as a member of the topics scheme with the skos:hasTopConcept relation, which is done when we PUT the concept to the top-concepts container.</p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/top-concepts/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1355,7 +953,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</thead>
 			<tbody>
-
 				<tr>
 					<td>Authorization</td>
 					<td>Basic ...</td>
@@ -1373,29 +970,19 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
 			_:b0
 				a c:AddMemberAction;
-				c:targetMember &#60;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/technology/&#62;.
+				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/technology/&#62;.
 		</code></pre>
-
 		<p>A successful PUT should result in HTTP status 200 OK.</p>
-
 		<p>Next, let's create one of the second-level concepts, Information Architecture (Concept 1.1), which is a narrower concept of the Design top concept we already created.
 			Create and issue
 			the following request.</p>
-
-		<p>
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code>
-		</p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1427,11 +1014,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
@@ -1442,22 +1025,10 @@ date: 2017-02-07 19:01:07
 				ldp:memberOfRelation skos:broader;
 				skos:prefLabel "Information Architecture".
 		</code></pre>
-
 		<p>A successful POST should result in HTTP status 201 Created.</p>
-
-		<p>
-			Next, we must make <span>Information Architecture (Concept 1.1) a narrower concept of Design (Concept 1) by adding it to the Design concept's container
-				membership.</span>
-		</p>
-
-		<p>
-			<span>Create and issue the following request:</span>
-		</p>
-
-		<p>
-			<span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/design/</code>
-		</p>
-
+		<p>Next, we must make <span>Information Architecture (Concept 1.1) a narrower concept of Design (Concept 1) by adding it to the Design concept's container membership.</span></p>
+		<p><span>Create and issue the following request:</span></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/design/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1484,36 +1055,18 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
 			_:b0
 				a c:AddMemberAction;
-				c:targetMember &#60;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/information-architecture/&#62;.
+				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/information-architecture/&#62;.
 		</code></pre>
-
-		<p>
-			If you examine the <code>design/</code> container now, you will see the membership triple for the <code>information-architecture/</code> container defined by <code>skos:narrower</code>.
-			If you examine the information-architecture/ container, you will see skos:broader linking to its parent, design/. Great.
-		</p>
-
+		<p>If you examine the <code>design/</code> container now, you will see the membership triple for the <code>information-architecture/</code> container defined by <code>skos:narrower</code>. If you examine the information-architecture/ container, you will see skos:broader linking to its parent, design/. Great.</p>
 		<p>Finally, we will create concepts 2.1 and 2.2, and then make them members of the parent Concept 2.</p>
-
-		<p>
-			<strong>Create Concept 2.1</strong>
-		</p>
-
-		<p>
-
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code>
-		</p>
-
-
+		<p><strong>Create Concept 2.1</strong></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1545,11 +1098,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
@@ -1560,15 +1109,8 @@ date: 2017-02-07 19:01:07
 				ldp:memberOfRelation skos:broader;
 				skos:prefLabel "HTML5".
 		</code></pre>
-
-		<p>
-			<strong>Create Concept 2.2</strong>
-		</p>
-
-		<p>
-			<span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/</code>
-		</p>
-
+		<p><strong>Create Concept 2.2</strong></p>
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1600,11 +1142,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix ldp:&#60;http://www.w3.org/ns/ldp#&#62;.
 			@prefix skos:&#60;http://www.w3.org/2004/02/skos/core#&#62;.
@@ -1615,16 +1153,8 @@ date: 2017-02-07 19:01:07
 				ldp:memberOfRelation skos:broader;
 				skos:prefLabel "JavaScript".
 		</code></pre>
-
-		<p>
-			<strong>Add Concept 2.1 to membership of parent</strong>
-		</p>
-
-		<p>
-			<span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/technology/</code>
-		</p>
-
-
+		<p><strong>Add Concept 2.1 to membership of parent</strong></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/technology/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1651,27 +1181,16 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
 			_:b0
 				a c:AddMemberAction;
-				c:targetMember &#60;{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/html5/&#62;.
+				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/html5/&#62;.
 		</code></pre>
-
-		<p>
-			<strong>Add Concept 2.2 to membership of parent</strong>
-		</p>
-
-		<p>
-			<span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/schemes/topics/technology/</code>
-		</p>
-
+		<p><strong>Add Concept 2.2 to membership of parent</strong></p>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/schemes/topics/technology/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1698,11 +1217,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
-		<p>
-			<strong>Body (required)</strong>
-		</p>
-
+		<p><strong>Body (required)</strong></p>
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
@@ -1710,17 +1225,12 @@ date: 2017-02-07 19:01:07
 				a c:AddMemberAction;
 				c:targetMember &#60;{{host}}/apps/taxonomy-hub/schemes/topics/javascript/&#62;.
 		</code></pre>
-
 	</section>
-
 </section>
 
 <section class="mainContent-section">
-
-	<h2 class="ui header">Secure the application</h2>
-
+	<h2 class="ui header">Secure the Application</h2>
 	<p>Setting up security for a Carbon application involves the following general steps:</p>
-
 	<ul>
 		<li>Create application roles</li>
 		<li>Create application users</li>
@@ -1728,29 +1238,17 @@ date: 2017-02-07 19:01:07
 		<li>Put roles into the role-hierarchy</li>
 		<li>Assign permissions on your application structure to the application roles</li>
 	</ul>
-
 	<section class="mainContent-subSection">
-
-		<h3 class="ui header">Create application roles</h3>
-
-		<p>
-			Roles allow us to control access to application resources. A role defines what kind of access a group of users have on one or more resources. For this app, we'll create
-			the two roles:
-		</p>
-
+		<h3 class="ui header">Create Application Roles</h3>
+		<p>Roles allow us to control access to application resources. A role defines what kind of access a group of users have on one or more resources. For this app, we'll create the two roles:</p>
 		<ul>
 			<li><strong>editor</strong> - Role for all available operations.</li>
 			<li><strong>user</strong> - Role for read-only operations.</li>
 		</ul>
-
 		<section class="mainContent-subSection">
-
 			<h4>Create the editor role</h4>
-
 			<p>Issue the following HTTP request to create the editor role.</p>
-
-			<p><span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/roles/</code></p>
-
+			<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/</code></p>
 			<table class="ui celled table">
 				<thead>
 					<tr>
@@ -1782,7 +1280,6 @@ date: 2017-02-07 19:01:07
 					</tr>
 				</tbody>
 			</table>
-
 			<pre><code class="turtle">
 				@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
 
@@ -1791,17 +1288,12 @@ date: 2017-02-07 19:01:07
 				    cs:name "editor";
 				    cs:description "Role for all available operations." .
 			</code></pre>
-
 		</section>
 
 		<section class="mainContent-subSection">
-
 			<h4>Create the user role</h4>
-
 			<p>Issue the following HTTP request to create the user role.</p>
-
-			<p><span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/roles/</code></p>
-
+			<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/</code></p>
 			<table class="ui celled table">
 				<thead>
 					<tr>
@@ -1842,21 +1334,15 @@ date: 2017-02-07 19:01:07
 				    cs:description "Role for read-only operations." .
 			</code></pre>
 		</section>
-
 	</section>
 
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Create application users</h3>
-
+		<h3 class="ui header">Create Application Users</h3>
 		<p>For this exercise, we'll create just two users - one to add to the editor role and another to add to the user role.</p>
-
 		<h4>Create agent, testuser1</h4>
-
 		<p>Issue the following HTTP request to create the first user (an Agent).</p>
-
-		<p><span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/agents/</code></p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1883,7 +1369,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
 			@prefix vcard:&#60;http://www.w3.org/2001/vcard-rdf/3.0#&#62;.
@@ -1893,13 +1378,9 @@ date: 2017-02-07 19:01:07
 			    vcard:email "user1@example.com" ;
 			    cs:password "password".
 		</code></pre>
-
 		<h4>Create agent, testuser2</h4>
-
 		<p>Issue the following HTTP request to create the second user (an Agent).</p>
-
-		<p><span class="ui blue horizontal label">POST</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/agents/</code></p>
-
+		<p><span class="ui blue horizontal label">POST</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1926,7 +1407,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix cs:&#60;https://carbonldp.com/ns/v1/security#&#62;.
 			@prefix vcard:&#60;http://www.w3.org/2001/vcard-rdf/3.0#&#62;.
@@ -1936,23 +1416,17 @@ date: 2017-02-07 19:01:07
 			    vcard:email "user2@example.com" ;
 			    cs:password "password".
 		</code></pre>
-
 	</section>
 
 
 	<section class="mainContent-subSection">
-		<h3 class="ui header">Assign users to roles</h3>
-
+		<h3 class="ui header">Assign Users to Roles</h3>
 		<p>In Carbon a role is similar to a user group. Roles are resources that can have one or more agents (users) as members.
 			In this step, we will assign testuser1 to the Editor role and testuser2 to the User role. To add an agent to a role, we
 			put the agent to the membership of the <code>agents</code> container within the container that represents the role.</p>
-
 		<h4>Add testuser1 to the editor role</h4>
-
 		<p>Issue the following HTTP request to add testuser1 to the editor role.</p>
-
-		<p><span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/roles/editor/agents/</code></p>
-
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/editor/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -1979,7 +1453,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
@@ -1987,13 +1460,9 @@ date: 2017-02-07 19:01:07
 				a c:AddMemberAction;
 				c:targetMember &#60;{{protoocolAndHost}}/apps/taxonomy-hub/agents/testuser1/&#62;.
 		</code></pre>
-
 		<h4>Add testuser2 to the user role</h4>
-
 		<p>Issue the following HTTP request to add testuser2 to the user role.</p>
-
-		<p><span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/roles/user/agents/</code></p>
-
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/user/agents/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -2020,32 +1489,23 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
 			_:b0
 				a c:AddMemberAction;
-				c:targetMember &#60;{{protocolAndHost}}/apps/taxonomy-hub/agents/testuser2/&#62;.
+				c:targetMember &#60;http://&lt;host&gt;/apps/taxonomy-hub/agents/testuser2/&#62;.
 		</code></pre>
 	</section>
 
 	<section class="mainContent-subSection">
-
-		<h3 class="ui header">Put the roles into the role-hierarchy</h3>
-
+		<h3 class="ui header">Put the Roles into the Role-Hierarchy</h3>
 		<p>We'll need to give permissions to our roles on resources. But we cannot assign permissions for the roles yet because the roles have not been positioned in the role
-			hierarchy.
-			Carbon has a role hierarchy so that permissions can be inherited from the parent in any place within the hierarchy. The hierarchy always starts at
+			hierarchy. Carbon has a role hierarchy so that permissions can be inherited from the parent in any place within the hierarchy. The hierarchy always starts at
 			<code>/apps/&lt;app-name&gt;/roles/app-admin/</code>. So, in order to be able to apply permissions (ACLs - Access Control List) on any resource, the roles that will
-			be part of an ACL will need
-			to exist
-			within the role hierarchy.</p>
-
-		<h4>Put the editor role into the role hierarchy</h4>
-
-		<p><span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/roles/app-admin/</code></p>
-
+			be part of an ACL will need to exist within the role hierarchy.</p>
+		<h4>Put the Editor Role into the Role Hierarchy/h4>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/app-admin/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -2072,7 +1532,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
@@ -2080,18 +1539,11 @@ date: 2017-02-07 19:01:07
 				a c:AddMemberAction;
 				c:targetMember &#60;/apps/taxonomy-hub/roles/editor/&#62;.
 		</code></pre>
-
 		<p>A successful PUT should result in HTTP status 200 OK.</p>
-
 		<p>If you inspect, the app-admin/ container, you should see the child role specified as follows:</p>
-
-		<p><code>&lt;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&gt; &lt;https://carbonldp.com/ns/v1/security#childRole&gt; &lt;https://local.carbonldp.com/apps/taxonomy-hub/roles/editor/&gt;</code>
-		</p>
-
-		<h4>Put the user role into the role hierarchy</h4>
-
-		<p><span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/roles/app-admin/</code></p>
-
+		<p><code>&lt;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&gt; &lt;https://carbonldp.com/ns/v1/security#childRole&gt; &lt;https://local.carbonldp.com/apps/taxonomy-hub/roles/editor/&gt;</code></p>
+		<h4>Put the User Role into the Role Hierarchy</h4>
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/roles/app-admin/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -2118,7 +1570,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			@prefix c:&#60;https://carbonldp.com/ns/v1/platform#&#62;.
 
@@ -2126,21 +1577,17 @@ date: 2017-02-07 19:01:07
 				a c:AddMemberAction;
 				c:targetMember &#60;/apps/taxonomy-hub/roles/user/&#62;.
 		</code></pre>
-
 		<p>A successful PUT should result in HTTP status 200 OK.</p>
-
 		<p>If you inspect, the app-admin/ container, you should see the child role specified as follows:</p>
-
 		<pre><code class="turtle">
 			&#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/app-admin/&#62;
 				&#60;https://carbonldp.com/ns/v1/security#childRole&#62;
 					&#60;https://local.carbonldp.com/apps/taxonomy-hub/roles/user/&#62;
 		</code></pre>
-
 	</section>
 	<section class="mainContent-subSection">
 
-		<h3 class="ui header">Assign permissions to the application roles</h3>
+		<h3 class="ui header">Assign Permissions to the Application Roles</h3>
 
 		<p>Next, we need to assign permissions to the application roles we've created. In Carbon, resources can have an AccessControlList (ACL),
 			which defines what permissions roles have on the given resource. Let's take a look.</p>
@@ -2148,7 +1595,7 @@ date: 2017-02-07 19:01:07
 		<p>Issue the following request to get the ACL for the application's root container, take notice that the interaction model used in this
 			request is RDFSource, as shown in the Prefer header.</p>
 
-		<p><span class="ui blue horizontal label">GET</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/~acl/</code></p>
+		<p><span class="ui blue horizontal label">GET</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/~acl/</code></p>
 
 		<table class="ui celled table">
 			<thead>
@@ -2171,9 +1618,7 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<p>The resulting ACL is shown below.</p>
-
 		<pre><code class="turtle">
 			&#60;https://local.carbonldp.com/apps/taxonomy-hub/~acl/&#62;
 				a &#60;https://carbonldp.com/ns/v1/security#AccessControlList&#62; ;
@@ -2216,21 +1661,15 @@ date: 2017-02-07 19:01:07
 				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true ;
 				&#60;https://carbonldp.com/ns/v1/platform#bNodeIdentifier&#62; "735e1e37-c2c4-4ae4-81ed-99a41d5b4ced" .
 		</code></pre>
-
 		<p>
 			The ACL defines a <code>accessControlEntry</code> and an <code>inheritableEntry</code>, each linking to an <code>AccessControlEntry</code> by way of a blank nodes.
 			The entry linked by <code>accessControlEntry</code> defines access to the resource itself. The entry linked by <code>inheritableEntry</code> defines permissions
 			that can be inherited by child resources when the child resources do not override them.
 		</p>
-
-
 		<h4>Give the Editor role all permissions and the user role READ permissions.</h4>
-
 		<p>The best way to modify permissions on a resource using the REST API is to start by getting the ACL for the resource as we've done here. We can then copy and
 			paste that ACL into a text editor, make some manual modifications, and then update the ACL.</p>
-
 		<p>For each role, repeat the following procedure.</p>
-
 		<ul>
 			<li>Copy an existing AccessControlEntry stanza and paste it at the bottom.
 			<li>Remove the <code>bNodeIdentifier</code> triple from the pasted stanza (Carbon will automatically generate a new one when we update the ACL).</li>
@@ -2238,13 +1677,9 @@ date: 2017-02-07 19:01:07
 			<li>Change the <code>security#subject</code> literal value to be the URI of the role that you are giving the permissions.</li>
 			<li>Add the new blank nodes to the <code>security#accessControlEntry</code> and <code>security#inheritableEntry</code> triples near the top.</li>
 		</ul>
-
 		<p>When you are done, you should end up with something similar to what is shown in the body of the following request. To update the ACL, you then issue a <code>PUT</code>
 			request to replace the ACL.</p>
-
-
-		<p><span class="ui blue horizontal label">PUT</span> <code>{{protocolAndHost}}/apps/taxonomy-hub/~acl/</code></p>
-
+		<p><span class="ui blue horizontal label">PUT</span> <code>http://&lt;host&gt;/apps/taxonomy-hub/~acl/</code></p>
 		<table class="ui celled table">
 			<thead>
 				<tr>
@@ -2271,7 +1706,6 @@ date: 2017-02-07 19:01:07
 				</tr>
 			</tbody>
 		</table>
-
 		<pre><code class="turtle">
 			&#60;https://local.carbonldp.com/apps/taxonomy-hub/~acl/&#62;
 				a &#60;https://carbonldp.com/ns/v1/security#AccessControlList&#62; ;
@@ -2343,21 +1777,11 @@ date: 2017-02-07 19:01:07
 				&#60;https://carbonldp.com/ns/v1/security#permission&#62; &#60;https://carbonldp.com/ns/v1/security#Read&#62; ;
 				&#60;https://carbonldp.com/ns/v1/security#granting&#62; true .
 		</code></pre>
-
-		<p>A successful PUT should result in HTTP status 200 OK.</p>
-
+		<p>A successful PUT should result in HTTP status <code>200 OK</code>.</p>
 	</section>
-
-
 </section>
 
 <section class="mainContent-section">
-
 	<h2 class="ui header">Conclusion</h2>
-
-	<p>This guide described how to build an example application using the Carbon LDP REST API. Normally, developers will prefer use of the App DEV GUI and the JavaScript SDK,
-		which together simplify the process of building an app. Still, all functions of the platform can be accessed via the REST API and those developers who understand it may
-		find
-		its use to be advantageous in some cases.</p>
-
+	<p>This guide described how to build an example application using the Carbon LDP REST API. Normally, developers will prefer use of the Carbon LDP Workbench (GUI) and the JavaScript SDK, which together simplify the process of building an app. Still, all functions of the platform can be accessed through the REST API and those developers who understand it may find its use to be advantageous in some cases.</p>
 </section>

--- a/source/documentation/rest-api/index.ejs
+++ b/source/documentation/rest-api/index.ejs
@@ -7,13 +7,13 @@ icon: ico-rest-api.svg
 date: 2017-01-27 15:45:43
 sidebar: disabled
 documents:
-- title: Getting started
+- title: Getting Started with the REST API
   link: getting-started
   summary: How to build an example application using the Carbon LDP REST API.
-- title: Object model
+- title: REST API Object Model
   link: object-model
   summary: A summary of the various types of resources you can manage and interact with using REST.
-- title: Interaction models
+- title: Interaction Models
   link: interaction-models
   summary: An explanation of the way you can interact with the resources on the Carbon Server.
 - title: Containers

--- a/source/documentation/rest-api/index.ejs
+++ b/source/documentation/rest-api/index.ejs
@@ -7,13 +7,13 @@ icon: ico-rest-api.svg
 date: 2017-01-27 15:45:43
 sidebar: disabled
 documents:
-- title: Getting Started with the REST API
+- title: Getting started with the REST API
   link: getting-started
   summary: How to build an example application using the Carbon LDP REST API.
-- title: REST API Object Model
+- title: REST API object model
   link: object-model
   summary: A summary of the various types of resources you can manage and interact with using REST.
-- title: Interaction Models
+- title: Interaction models
   link: interaction-models
   summary: An explanation of the way you can interact with the resources on the Carbon Server.
 - title: Containers

--- a/themes/CarbonLDP/layout/documentation-home.ejs
+++ b/themes/CarbonLDP/layout/documentation-home.ejs
@@ -3,14 +3,14 @@
         <div class="ui four column center aligned padded stackable grid">
             <div class="row">
                 <div class="ten wide column">
-                    <h1 class="categoriesMenu-title"> Carbon LDP Documentation</h1>
+                    <h1 class="categoriesMenu-title"> Carbon LDP documentation</h1>
                 </div>
             </div>
 
             <div class="row categoriesMenu">
                 <a href="#quick-guide" class="column categoriesMenu-button">
                     <%- svg("assets/images/ico-open-book.svg", "ui centered circular image categoriesMenu-icon")%>
-                    <div class="categoriesMenu-categoryTitle">Quick Start</div>
+                    <div class="categoriesMenu-categoryTitle">Quick start</div>
                 </a>
                 <a href="#essential-concepts" class="column categoriesMenu-button">
                     <%- svg("assets/images/ico-books.svg", "ui centered circular image categoriesMenu-icon")%>
@@ -37,14 +37,14 @@
 
             <div class="category-titleContainer">
                 <%- svg("assets/images/ico-open-book.svg", "ui left floated image category-icon")%>
-                <h2 class="category-title">Quick Start</h2>
+                <h2 class="category-title">Quick start</h2>
             </div>
 
             <div class="category-description">
                 <p>Start now!</p>
                 <div class="ui bulleted list">
                     <div class="item category-item">
-                        <div><a class="category-itemTitle" href="quick-start-guide">Quick Start Guide</a></div>
+                        <div><a class="category-itemTitle" href="quick-start-guide">Quick start guide</a></div>
                         <p>Get started now, with this easy to follow, quick start guide</p>
                     </div>
                 </div>
@@ -56,7 +56,7 @@
 
             <div class="category-titleContainer">
                 <%- svg("assets/images/ico-books.svg", "ui left floated image category-icon")%>
-                <h2 class="category-title">Essential Concepts</h2>
+                <h2 class="category-title">Essential concepts</h2>
             </div>
 
             <div class="category-description">


### PR DESCRIPTION
Fix #115
- Make all links on REST API index consistent with page titles.
- Make all links on Essential Concepts index consistent with page titles.
- Add a helpful notes to README.md
- Remove cloud references. 
- Consolidate steps to make end-to-end process shorter.
- Clarify (improve) descriptive copy text.
- Convert examples from Turtle to TriG.